### PR TITLE
Extend request timeout to 5 minutes

### DIFF
--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -1,6 +1,7 @@
 ROOT = File.expand_path(File.join(File.dirname(__FILE__), '..'))
 
 worker_processes 5
+timeout 300
 preload_app true
 pid File.join(ROOT, 'tmp', 'pids', 'unicorn.pid')
 stdout_path '/var/log/aaf/reporting/unicorn/stdout.log'


### PR DESCRIPTION
Report generation for large datasets is timing out in users browsers
resulting in a 502 response.

This initial change will allow the ruby process more time to generate
the report response. A change to the associated Apache proxy connection
will also be added in AAF Ansible.

This is a partial solution for #148.