### PR TITLE
Correct date format in JSON for sub reg reports

### DIFF
--- a/app/reports/subscriber_registrations_report.rb
+++ b/app/reports/subscriber_registrations_report.rb
@@ -18,7 +18,7 @@ class SubscriberRegistrationsReport < TabularReport
     objects.map do |o|
       registration_date = o.activations.map(&:activated_at).min
 
-      [o.name, registration_date.to_s]
+      [o.name, registration_date.xmlschema]
     end
   end
 


### PR DESCRIPTION
Ensures that javascript engines in browsers can correctly display
date data, previously this resulted in NaN output in at least Firefox.

Closes #146.