### PR TITLE
Fix implicit Torba step during "rake assets:precompile"

### DIFF
--- a/config/boot.rb
+++ b/config/boot.rb
@@ -2,4 +2,3 @@
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
 
 require 'bundler/setup'
-require 'torba/verify'


### PR DESCRIPTION
Missed this one in review, but hit it in my local environment while testing something unrelated.