### PR TITLE
Fix run speed of utilization reports

### DIFF
--- a/app/reports/identity_provider_destination_services_report.rb
+++ b/app/reports/identity_provider_destination_services_report.rb
@@ -18,6 +18,6 @@ class IdentityProviderDestinationServicesReport < TabularReport
   private
 
   def rows
-    tabular_sessions(:service_provider, idp_sessions)
+    tabular_sessions(ServiceProvider, idp_sessions)
   end
 end

--- a/app/reports/identity_provider_utilization_report.rb
+++ b/app/reports/identity_provider_utilization_report.rb
@@ -16,6 +16,6 @@ class IdentityProviderUtilizationReport < TabularReport
   end
 
   def rows
-    tabular_sessions(:identity_provider)
+    tabular_sessions(IdentityProvider)
   end
 end

--- a/app/reports/reports_shared_methods.rb
+++ b/app/reports/reports_shared_methods.rb
@@ -63,7 +63,9 @@ module ReportsSharedMethods
   def tabular_sessions(target, session_objects = sessions)
     sql = tabular_sessions_query(target, session_objects)
 
-    target.connection.execute(sql).map { |a| a.map(&:to_s) }
+    target.connection.execute(sql)
+          .map { |a| a.map(&:to_s) }
+          .sort_by { |a| a[0].downcase }
   end
 
   TARGET_OPTS = {

--- a/app/reports/reports_shared_methods.rb
+++ b/app/reports/reports_shared_methods.rb
@@ -61,12 +61,29 @@ module ReportsSharedMethods
   end
 
   def tabular_sessions(target, session_objects = sessions)
-    output = session_objects
-             .preload(target)
-             .group_by(&target)
-             .select { |obj| obj }
-             .map { |obj, val| [obj.name, val.count.to_s] }
+    sql = tabular_sessions_query(target, session_objects)
 
-    output.sort_by { |r| r[0] }
+    target.connection.execute(sql).map { |a| a.map(&:to_s) }
+  end
+
+  TARGET_OPTS = {
+    IdentityProvider => {
+      assoc: :identity_provider,
+      foreign_key: :selected_idp
+    }.freeze,
+    ServiceProvider => {
+      assoc: :service_provider,
+      foreign_key: :initiating_sp
+    }.freeze
+  }.freeze
+
+  def tabular_sessions_query(target, session_objects)
+    opts = TARGET_OPTS[target]
+
+    session_objects
+      .joins(opts[:assoc])
+      .group(opts[:foreign_key])
+      .select(target.arel_table[:name], 'count(*)')
+      .to_sql
   end
 end

--- a/app/reports/service_provider_source_identity_providers_report.rb
+++ b/app/reports/service_provider_source_identity_providers_report.rb
@@ -18,6 +18,6 @@ class ServiceProviderSourceIdentityProvidersReport < TabularReport
   private
 
   def rows
-    tabular_sessions(:identity_provider, sp_sessions)
+    tabular_sessions(IdentityProvider, sp_sessions)
   end
 end

--- a/app/reports/service_provider_utilization_report.rb
+++ b/app/reports/service_provider_utilization_report.rb
@@ -16,6 +16,6 @@ class ServiceProviderUtilizationReport < TabularReport
   end
 
   def rows
-    tabular_sessions(:service_provider)
+    tabular_sessions(ServiceProvider)
   end
 end

--- a/db/migrate/20160613235908_add_indexes_for_utilization_reports.rb
+++ b/db/migrate/20160613235908_add_indexes_for_utilization_reports.rb
@@ -1,0 +1,9 @@
+class AddIndexesForUtilizationReports < ActiveRecord::Migration
+  def change
+    add_index :discovery_service_events, [:unique_id, :phase], unique: true
+    remove_index :discovery_service_events, column: [:phase, :unique_id],
+                                            unique: true
+    remove_index :discovery_service_events, column: :timestamp
+    add_index :discovery_service_events, [:phase, :timestamp]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160330231532) do
+ActiveRecord::Schema.define(version: 20160613235908) do
 
   create_table "activations", force: :cascade do |t|
     t.integer  "federation_object_id",   limit: 4,   null: false
@@ -92,8 +92,8 @@ ActiveRecord::Schema.define(version: 20160330231532) do
     t.string   "selected_idp",     limit: 255
   end
 
-  add_index "discovery_service_events", ["phase", "unique_id"], name: "index_discovery_service_events_on_phase_and_unique_id", unique: true, using: :btree
-  add_index "discovery_service_events", ["timestamp"], name: "index_discovery_service_events_on_timestamp", using: :btree
+  add_index "discovery_service_events", ["phase", "timestamp"], name: "index_discovery_service_events_on_phase_and_timestamp", using: :btree
+  add_index "discovery_service_events", ["unique_id", "phase"], name: "index_discovery_service_events_on_unique_id_and_phase", unique: true, using: :btree
 
   create_table "federated_login_events", force: :cascade do |t|
     t.string   "relying_party",         limit: 255, null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -82,22 +82,69 @@ ActiveRecord::Base.transaction do
     end
   end
 
-  start = 1.month.ago.utc.to_i
+  puts
+
+  start = 3.months.ago.utc.to_i
   finish = Time.now.utc.to_i
-  time = start
 
-  while time < finish
-    attrs = { service_provider: sps.sample, timestamp: Time.zone.at(time) }
+  events = Enumerator.new do |y|
+    time = start
 
-    create(:discovery_service_event, attrs.slice(:service_provider, :timestamp))
+    while time < finish
+      attrs = { user_agent: 'Mozilla/5.0', timestamp: Time.zone.at(time),
+                ip: Faker::Internet.ip_v4_address, group: Faker::Lorem.word,
+                unique_id: SecureRandom.urlsafe_base64, phase: 'request',
+                initiating_sp: sps.sample.entity_id }
 
-    if rand < 0.95
-      attrs[:identity_provider] = idps.sample
-      attrs[:timestamp] = Time.zone.at(time + rand(30))
-      create(:discovery_service_event, :response, attrs)
+      y << attrs
+
+      if rand < 0.95
+        y << attrs.merge(
+          phase: 'response',
+          selection_method: %w(manual cookie).sample,
+          selected_idp: idps.sample.entity_id,
+          timestamp: Time.zone.at(time + rand(30))
+        )
+      end
+
+      time += rand(60)
+    end
+  end
+
+  def sql_quote(str)
+    ActiveRecord::Base.connection.quote(str)
+  end
+
+  events.each_slice(1000) do |slice|
+    sqlio = StringIO.new
+    sqlio.puts(
+      'INSERT INTO discovery_service_events ' \
+      '(user_agent, ip, `group`, phase, unique_id, timestamp,' \
+      ' selection_method, return_url, initiating_sp, selected_idp,' \
+      ' created_at, updated_at) ' \
+      'VALUES '
+    )
+
+    slice.each do |attrs|
+      sqlio.puts(
+        format(
+          '(%<user_agent>s, %<ip>s, %<group>s, %<phase>s, %<unique_id>s,' \
+          ' %<timestamp>s, %<selection_method>s, %<return_url>s,' \
+          ' %<initiating_sp>s, %<selected_idp>s, now(), now()),',
+          Hash.new('NULL').merge(attrs.transform_values { |v| sql_quote(v) })
+        )
+      )
     end
 
-    time += rand(3600)
+    sqlio.seek(-2, IO::SEEK_CUR)
+    sqlio.puts(';')
+
+    ActiveRecord::Base.connection.execute(sqlio.string)
+
+    i += slice.length
+    offset = (slice.last[:timestamp].to_i - start)
+    pc = 100 * offset.to_f / (finish - start).to_f
+    print("\rCreating Events: #{i} (#{pc.to_i}%)\e[0K")
   end
 end
 

--- a/spec/support/utilization_reports.rb
+++ b/spec/support/utilization_reports.rb
@@ -4,56 +4,73 @@ RSpec.shared_context 'Utilization Report' do
 
   let!(:start) { 10.days.ago.beginning_of_day }
   let!(:finish) { 1.day.ago.beginning_of_day }
-
   let(:header) { [%w(Name Sessions)] }
 
-  let(:obj_01) { create object_type }
-  let(:obj_02) { create object_type }
-  let(:obj_03) { create object_type }
-  let(:obj_04) { create object_type }
-
+  let(:included_objects) { create_list(object_type, rand(4..7)) }
+  let(:before_objects) { create_list(object_type, rand(1..3)) }
+  let(:after_objects) { create_list(object_type, rand(1..3)) }
+  let(:objects) { included_objects + before_objects + after_objects }
   let(:report) { subject.generate }
 
   context 'a utilization report' do
-    let(:report) { subject.generate }
-
     it 'must contain type, header, title' do
       expect(report).to include(type: type, title: title, header: header)
     end
   end
 
   context '#Generate' do
-    before do
-      create_list :discovery_service_event, 5, :response,
-                  target => obj_01.entity_id,
-                  timestamp: start
+    let(:counts) do
+      objects.each_with_object({}) { |e, a| e[a.id] = rand(1..10) }
+    end
 
-      create_list :discovery_service_event, 5, :response,
-                  timestamp: start
+    def create_events(objects, start, finish)
+      objects.each_with_object({}) do |o, a|
+        events = Array.new(rand(1..5)) do
+          create(:discovery_service_event, :response,
+                 target => o.entity_id,
+                 timestamp: Faker::Time.between(start, finish))
+        end
 
-      create_list :discovery_service_event, 5, :response,
-                  target => obj_02.entity_id,
-                  timestamp: start + 4.days
+        a[o.id] = events.length
+      end
+    end
 
-      create_list :discovery_service_event, 5, :response,
-                  target => obj_03.entity_id,
-                  timestamp: start - 2.days
+    let!(:included_object_event_counts) do
+      create_events(included_objects, start, finish)
+    end
 
-      create_list :discovery_service_event, 5, :response,
-                  target => obj_04.entity_id,
-                  timestamp: finish + 1.minute
+    let!(:before_object_event_counts) do
+      create_events(before_objects, 1.week.until(start), start)
+    end
+
+    let!(:after_object_event_counts) do
+      create_events(after_objects, finish, 1.week.since(finish))
     end
 
     it 'should render a report row' do
-      name_01 = obj_01.name
-      name_02 = obj_02.name
-      name_03 = obj_03.name
-      name_04 = obj_04.name
+      expected = included_objects.map do |o|
+        [o.name, included_object_event_counts[o.id].to_s]
+      end
 
-      expect(report[:rows]).to include([name_01, '5'])
-      expect(report[:rows]).to include([name_02, '5'])
-      expect(report[:rows]).not_to include([name_03, anything])
-      expect(report[:rows]).not_to include([name_04, anything])
+      expect(report[:rows]).to match_array(expected)
+    end
+
+    it 'sorts the rows in name order' do
+      names = report[:rows].map(&:first)
+      expect(names).to eq(names.sort_by(&:downcase))
+    end
+
+    context 'with random case permutations' do
+      before do
+        objects.each do |o|
+          o.update!(name: o.name.send([:upcase, :downcase].sample))
+        end
+      end
+
+      it 'sorts the rows in name order' do
+        names = report[:rows].map(&:first)
+        expect(names).to eq(names.sort_by(&:downcase))
+      end
     end
   end
 end


### PR DESCRIPTION
A couple of issues were at play here which caused these reports to run far too slowly:

* Original implementation was loading every `DiscoveryServiceEvent` into an ActiveRecord object, which is _far_ too slow for the amount of data we have;
* The query to select relevant `DiscoveryServiceEvent` records was not hitting the correct index, leading to performance indistinguishable from a full table scan.

Switching to an aggregate query and fixing the index makes a dramatic difference.

cc @toomaj If you want to also look at what I've done here.