### PR TITLE
Refactor #permissions to always be optimized query 

### DIFF
--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -4,17 +4,12 @@ class Subject < ActiveRecord::Base
 
   has_many :subject_roles
   has_many :roles, through: :subject_roles
-
-  has_many :permissions_alias, through: :roles,
-                               class_name: 'Permission',
-                               source: :permissions
-
   has_many :automated_report_subscriptions
 
   valhammer
 
   def permissions
-    permissions_alias.map(&:value)
+    roles.joins(:permissions).pluck('permissions.value')
   end
 
   def functioning?

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -4,12 +4,17 @@ class Subject < ActiveRecord::Base
 
   has_many :subject_roles
   has_many :roles, through: :subject_roles
+
+  has_many :permissions_alias, through: :roles,
+                               class_name: 'Permission',
+                               source: :permissions
+
   has_many :automated_report_subscriptions
 
   valhammer
 
   def permissions
-    roles.flat_map { |role| role.permissions.map(&:value) }
+    permissions_alias.map(&:value)
   end
 
   def functioning?


### PR DESCRIPTION
Fixes #161.
When incoming subject has only one permission, then preloading
permissions causes `Bullet` to raise `unused` preload exception,
and if subject has more that one permission then Bullet raises
`SELECT N+1` exception when permissions are not preloaded.
My approach to fix this problem is to establish an extra
association between `subject` and related `permissions`
through `roles`, and invoke permissions directly on subject
to solve `unused preload` or `N+1 Query` issues.