### PR TITLE
Update Lipstick to fix asset precompilation bug

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 
 GIT
   remote: https://github.com/ausaccessfed/aaf-lipstick
-  revision: 48aeef08fe3f5326d4a640ab35fe304f296086c0
+  revision: 045bed2fb8c40fdf501d9de23ed93350acf71503
   branch: develop
   specs:
     aaf-lipstick (1.1.0)


### PR DESCRIPTION
When deployed in a clean environment, running `rake assets:precompile` would raise the following exception:

```
NoMethodError: undefined method `find_asset' for nil:NilClass
aaf-lipstick-48aeef08fe3f/lib/lipstick/images/email_banner.rb:90:in `logo'
aaf-lipstick-48aeef08fe3f/lib/lipstick/images/email_banner.rb:100:in `logo_w'
aaf-lipstick-48aeef08fe3f/lib/lipstick/images/email_banner.rb:157:in `total_w'
aaf-lipstick-48aeef08fe3f/lib/lipstick/images/email_banner.rb:125:in `margin_x'
aaf-lipstick-48aeef08fe3f/lib/lipstick/images/email_banner.rb:131:in `title_x'
aaf-lipstick-48aeef08fe3f/lib/lipstick/images/email_banner.rb:81:in `annotate_title'
aaf-lipstick-48aeef08fe3f/lib/lipstick/images/email_banner.rb:43:in `to_png'
aaf-lipstick-48aeef08fe3f/lib/lipstick/images/processor.rb:20:in `email_banner'
aaf-lipstick-48aeef08fe3f/lib/lipstick/images/processor.rb:16:in `run'
aaf-lipstick-48aeef08fe3f/lib/lipstick/images/processor.rb:14:in `eval'
aaf-lipstick-48aeef08fe3f/lib/lipstick/images/processor.rb:14:in `run'
aaf-lipstick-48aeef08fe3f/lib/lipstick/images/processor.rb:28:in `evaluate'
```

This was fixed in ausaccessfed/aaf-lipstick#64.