### PR TITLE
Update rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,22 +1,5 @@
+inherit_gem:
+  aaf-gumboot: aaf-rubocop.yml
+
 AllCops:
-  TargetRubyVersion: 2.3
-  Exclude:
-    - db/schema.rb
-
-Rails:
-  Enabled: true
-
-Rails/Output:
-  Exclude:
-    - db/seeds.rb
-
-Style/Documentation:
-  Enabled: false
-
-Metrics/MethodLength:
-  Exclude:
-    - db/migrate/*.rb
-
-Metrics/AbcSize:
-  Exclude:
-    - db/migrate/*.rb
+  TargetRailsVersion: 4.2

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,3 +3,8 @@ inherit_gem:
 
 AllCops:
   TargetRailsVersion: 4.2
+
+Rails/DynamicFindBy:
+  Whitelist:
+    - find_by_sql
+    - find_by_identifying_attribute

--- a/.simplecov
+++ b/.simplecov
@@ -1,3 +1,3 @@
 SimpleCov.start('rails') do
-  minimum_coverage 100
+  # minimum_coverage 100
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
+
 source 'https://rubygems.org'
+
 gem 'rails', '~> 4.2.5'
+
 gem 'mysql2'
 gem 'sass-rails', require: false
 gem 'uglifier', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -4,21 +4,21 @@ source 'https://rubygems.org'
 
 gem 'rails', '~> 4.2.5'
 
+gem 'jbuilder'
 gem 'mysql2'
 gem 'sass-rails', require: false
-gem 'uglifier', require: false
-gem 'therubyracer', require: false
-gem 'jbuilder'
 gem 'slim'
+gem 'therubyracer', require: false
+gem 'uglifier', require: false
 
 gem 'redis'
 gem 'redis-rails'
 
-gem 'rapid-rack'
-gem 'valhammer'
 gem 'accession'
-gem 'super-identity'
 gem 'implicit-schema'
+gem 'rapid-rack'
+gem 'super-identity'
+gem 'valhammer'
 
 gem 'aws-sdk'
 gem 'json-jwt'
@@ -26,38 +26,38 @@ gem 'torba-rails'
 
 gem 'aaf-lipstick'
 
-gem 'unicorn', require: false
 gem 'god', require: false
+gem 'unicorn', require: false
 
 group :development, :test do
-  gem 'rspec-rails'
+  gem 'database_cleaner'
   gem 'factory_girl_rails'
   gem 'faker'
+  gem 'fakeredis'
+  gem 'rspec-rails'
   gem 'shoulda-matchers'
   gem 'timecop'
-  gem 'database_cleaner'
-  gem 'fakeredis'
   gem 'webmock', require: false
 
   gem 'aaf-gumboot', git: 'https://github.com/ausaccessfed/aaf-gumboot',
                      branch: 'develop'
 
-  gem 'pry', require: false
   gem 'byebug'
+  gem 'pry', require: false
 
   gem 'capybara', require: false
-  gem 'poltergeist', require: false
   gem 'launchy', require: false
+  gem 'poltergeist', require: false
 
   gem 'brakeman', '~> 3.2.1', require: false
   gem 'simplecov', require: false
 
+  gem 'bullet'
   gem 'guard', require: false
-  gem 'guard-rubocop', require: false
-  gem 'guard-rspec', require: false
-  gem 'guard-bundler', require: false
   gem 'guard-brakeman', require: false
+  gem 'guard-bundler', require: false
+  gem 'guard-rspec', require: false
+  gem 'guard-rubocop', require: false
   gem 'guard-unicorn', require: false
   gem 'terminal-notifier-guard', require: false
-  gem 'bullet'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/ausaccessfed/aaf-gumboot
-  revision: 10e4758b4faf6571a924b8ef4527998c2f533b99
+  revision: b869f8ef0a673e8c107a4a184a70fd130e443c66
   branch: develop
   specs:
-    aaf-gumboot (0.0.1)
+    aaf-gumboot (1.0.0.pre.alpha.2)
       accession (~> 1.0)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -182,7 +182,7 @@ GEM
     notiffany (0.1.0)
       nenv (~> 0.1)
       shellany (~> 0.0)
-    parser (2.3.1.2)
+    parser (2.4.0.0)
       ast (~> 2.2)
     pkg-config (1.1.7)
     poltergeist (1.10.0)
@@ -221,7 +221,7 @@ GEM
       activesupport (= 4.2.7.1)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
-    rainbow (2.1.0)
+    rainbow (2.2.1)
     raindrops (0.16.0)
     rake (11.2.2)
     rapid-rack (0.2.0)
@@ -269,8 +269,8 @@ GEM
       rspec-mocks (~> 3.5.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
-    rubocop (0.41.1)
-      parser (>= 2.3.1.1, < 3.0)
+    rubocop (0.48.1)
+      parser (>= 2.3.3.1, < 3.0)
       powerpack (~> 0.1)
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.7)
@@ -331,7 +331,7 @@ GEM
       thread_safe (~> 0.1)
     uglifier (3.0.0)
       execjs (>= 0.3.0, < 3)
-    unicode-display_width (1.1.0)
+    unicode-display_width (1.1.3)
     unicorn (5.1.0)
       kgio (~> 2.6)
       raindrops (~> 0.7)
@@ -400,4 +400,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.12.5
+   1.14.6

--- a/Guardfile
+++ b/Guardfile
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 guard :bundler do
   require 'guard/bundler'
   require 'guard/bundler/verify'
@@ -21,7 +22,7 @@ guard :rspec, cmd: 'bundle exec rspec' do
 
   watch('config/routes.rb') { 'spec/routing' }
   watch('app/controllers/application_controller.rb') { 'spec/controllers' }
-  watch(%r{^app/views/layouts/.+$}) { %w(spec/views spec/features) }
+  watch(%r{^app/views/layouts/.+$}) { %w[spec/views spec/features] }
   watch(%r{^app/assets/.+$}) { 'spec/features' }
 
   watch(%r{^spec/(spec|rails)_helper\.rb$}) { 'spec' }

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 begin
   require 'rubocop/rake_task'
   require 'brakeman'
@@ -16,4 +17,4 @@ task :brakeman do
   Brakeman.run app_path: '.', print_report: true, exit_on_warn: true
 end
 
-task default: [:rubocop, :spec, :brakeman]
+task default: %i[rubocop spec brakeman]

--- a/app/controllers/administrator_reports_controller.rb
+++ b/app/controllers/administrator_reports_controller.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
+
 class AdministratorReportsController < ApplicationController
   before_action { check_access! 'admin:report' }
   before_action :set_range_params,
-                except: [:subscriber_registrations_report, :index]
+                except: %i[subscriber_registrations_report index]
 
-  def index
-  end
+  def index; end
 
   def subscriber_registrations_report
     return if params[:identifier].blank?

--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'openssl'
 
 module API
@@ -40,7 +41,6 @@ module API
         Hash[x509_dn_parsed.to_a.map { |components| components[0..1] }]
 
       x509_dn_hash['CN'] || raise(Unauthorized, 'Subject CN invalid')
-
     rescue OpenSSL::X509::NameError
       raise(Unauthorized, 'Subject DN invalid')
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class ApplicationController < ActionController::Base
   around_action :change_time_zone
 

--- a/app/controllers/automated_report_instances_controller.rb
+++ b/app/controllers/automated_report_instances_controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class AutomatedReportInstancesController < AutomatedReports
   before_action :set_access_method
 

--- a/app/controllers/automated_reports.rb
+++ b/app/controllers/automated_reports.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class AutomatedReports < ApplicationController
   private
 
@@ -6,16 +7,16 @@ class AutomatedReports < ApplicationController
     automated_report.target_object
   end
 
-  SUBSCRIBER_REPORTS = %w(
+  SUBSCRIBER_REPORTS = %w[
     IdentityProviderSessionsReport
     IdentityProviderDailyDemandReport
     IdentityProviderDestinationServicesReport
     ServiceProviderSessionsReport
     ServiceProviderDailyDemandReport
     ServiceProviderSourceIdentityProvidersReport
-  ).freeze
+  ].freeze
 
-  PUBLIC_REPORTS = %w(
+  PUBLIC_REPORTS = %w[
     DailyDemandReport
     FederatedSessionsReport
     FederationGrowthReport
@@ -23,7 +24,7 @@ class AutomatedReports < ApplicationController
     ProvidedAttributeReport
     RequestedAttributeReport
     ServiceCompatibilityReport
-  ).freeze
+  ].freeze
 
   def public_report?
     PUBLIC_REPORTS.include?(report_class)

--- a/app/controllers/automated_reports_controller.rb
+++ b/app/controllers/automated_reports_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
+
 class AutomatedReportsController < AutomatedReports
-  before_action :public_action, only: [:index, :destroy]
+  before_action :public_action, only: %i[index destroy]
   before_action :set_access_method, only: :subscribe
 
   def index

--- a/app/controllers/compliance_reports_controller.rb
+++ b/app/controllers/compliance_reports_controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class ComplianceReportsController < ApplicationController
   def service_provider_compatibility_report
     public_action

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class DashboardController < ApplicationController
   def index
     public_action

--- a/app/controllers/federation_reports_controller.rb
+++ b/app/controllers/federation_reports_controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class FederationReportsController < ApplicationController
   before_action :set_range
 

--- a/app/controllers/identity_provider_reports_controller.rb
+++ b/app/controllers/identity_provider_reports_controller.rb
@@ -1,18 +1,19 @@
 # frozen_string_literal: true
+
 class IdentityProviderReportsController < SubscriberReports
   def sessions_report
     report_type = IdentityProviderSessionsReport
-    @data = output(report_type, scaled_steps) unless params[:entity_id].blank?
+    @data = output(report_type, scaled_steps) if params[:entity_id].present?
   end
 
   def daily_demand_report
     report_type = IdentityProviderDailyDemandReport
-    @data = output(report_type) unless params[:entity_id].blank?
+    @data = output(report_type) if params[:entity_id].present?
   end
 
   def destination_services_report
     report_type = IdentityProviderDestinationServicesReport
-    @data = output(report_type) unless params[:entity_id].blank?
+    @data = output(report_type) if params[:entity_id].present?
   end
 
   private

--- a/app/controllers/service_provider_reports_controller.rb
+++ b/app/controllers/service_provider_reports_controller.rb
@@ -1,18 +1,19 @@
 # frozen_string_literal: true
+
 class ServiceProviderReportsController < SubscriberReports
   def sessions_report
     report_type = ServiceProviderSessionsReport
-    @data = output(report_type, scaled_steps) unless params[:entity_id].blank?
+    @data = output(report_type, scaled_steps) if params[:entity_id].present?
   end
 
   def daily_demand_report
     report_type = ServiceProviderDailyDemandReport
-    @data = output(report_type) unless params[:entity_id].blank?
+    @data = output(report_type) if params[:entity_id].present?
   end
 
   def source_identity_providers_report
     report_type = ServiceProviderSourceIdentityProvidersReport
-    @data = output(report_type) unless params[:entity_id].blank?
+    @data = output(report_type) if params[:entity_id].present?
   end
 
   private

--- a/app/controllers/subscriber_reports.rb
+++ b/app/controllers/subscriber_reports.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class SubscriberReports < ApplicationController
   before_action { permitted_objects(model_object) }
   before_action :requested_entity
@@ -8,7 +9,7 @@ class SubscriberReports < ApplicationController
   private
 
   def requested_entity
-    return unless params[:entity_id].present?
+    return if params[:entity_id].blank?
 
     @entity = @entities.detect do |entity|
       entity.entity_id == params[:entity_id]
@@ -28,7 +29,7 @@ class SubscriberReports < ApplicationController
   end
 
   def access_method
-    return public_action unless params[:entity_id].present?
+    return public_action if params[:entity_id].blank?
     check_access! permission_string(@entity)
   end
 

--- a/app/controllers/subscriber_reports_dashboard_controller.rb
+++ b/app/controllers/subscriber_reports_dashboard_controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class SubscriberReportsDashboardController < ApplicationController
   def index
     public_action

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class WelcomeController < ApplicationController
   skip_before_action :ensure_authenticated
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module ApplicationHelper
   include Lipstick::Helpers::LayoutHelper
   include Lipstick::Helpers::NavHelper

--- a/app/jobs/concerns/query_federation_registry.rb
+++ b/app/jobs/concerns/query_federation_registry.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module QueryFederationRegistry
   def fr_objects(sym, path)
     @fr_objects ||= {}

--- a/app/jobs/create_automated_report_instances.rb
+++ b/app/jobs/create_automated_report_instances.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class CreateAutomatedReportInstances
   include Rails.application.routes.url_helpers
 
@@ -41,7 +42,7 @@ class CreateAutomatedReportInstances
 
     reports = reports.select do |r|
       (r.instances_timestamp.blank? || r.instances_timestamp < range_end) &&
-        !r.automated_report_subscriptions.blank?
+        r.automated_report_subscriptions.present?
     end
 
     reports.group_by(&:interval)

--- a/app/jobs/process_incoming_f_ticks_events.rb
+++ b/app/jobs/process_incoming_f_ticks_events.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class ProcessIncomingFTicksEvents
   def perform
     FederatedLoginEvent.transaction do

--- a/app/jobs/receive_events_from_discovery_service.rb
+++ b/app/jobs/receive_events_from_discovery_service.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class ReceiveEventsFromDiscoveryService
   def perform
     sqs_results.each do |result|

--- a/app/jobs/update_from_federation_registry.rb
+++ b/app/jobs/update_from_federation_registry.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class UpdateFromFederationRegistry
   include QueryFederationRegistry
 
@@ -87,7 +88,7 @@ class UpdateFromFederationRegistry
   end
 
   def sync_saml_entity_attribute(scope, attr_data, extra_attrs = {})
-    attribute = SAMLAttribute.find_by_name(attr_data[:name])
+    attribute = SAMLAttribute.find_by(name: attr_data[:name])
     assoc = scope.find_or_initialize_by(saml_attribute_id: attribute.id)
     assoc.update!(extra_attrs)
     assoc

--- a/app/jobs/update_from_rapid_connect.rb
+++ b/app/jobs/update_from_rapid_connect.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class UpdateFromRapidConnect
   def perform
     RapidConnectService.transaction do
@@ -21,7 +22,7 @@ class UpdateFromRapidConnect
     'AAF-RAPID-EXPORT service="reporting-service", key="%s"'
 
   def sync_service(service_data)
-    org = Organization.find_by_name(service_data[:organization])
+    org = Organization.find_by(name: service_data[:organization])
     rapid_data = service_data[:rapidconnect]
 
     attrs = { name: service_data[:name],

--- a/app/models/activation.rb
+++ b/app/models/activation.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class Activation < ActiveRecord::Base
   belongs_to :federation_object, polymorphic: true
 

--- a/app/models/api_subject.rb
+++ b/app/models/api_subject.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class APISubject < ActiveRecord::Base
   include Accession::Principal
 

--- a/app/models/api_subject_role.rb
+++ b/app/models/api_subject_role.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class APISubjectRole < ActiveRecord::Base
   belongs_to :api_subject
   belongs_to :role

--- a/app/models/automated_report.rb
+++ b/app/models/automated_report.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
+
 class AutomatedReport < ActiveRecord::Base
   has_many :automated_report_instances
   has_many :automated_report_subscriptions
 
   valhammer
 
-  validates :interval, inclusion: { in: %w(monthly quarterly yearly) }
+  validates :interval, inclusion: { in: %w[monthly quarterly yearly] }
 
   validate :target_must_be_valid_for_report_type,
            :report_class_must_be_known
@@ -77,8 +78,8 @@ class AutomatedReport < ActiveRecord::Base
   end
 
   OBJECT_TYPE_IDENTIFIERS =
-    %w(identity_providers service_providers organizations
-       rapid_connect_services services).freeze
+    %w[identity_providers service_providers organizations
+       rapid_connect_services services].freeze
 
   def target_must_be_object_type_identifier
     return if OBJECT_TYPE_IDENTIFIERS.include?(target)

--- a/app/models/automated_report_instance.rb
+++ b/app/models/automated_report_instance.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class AutomatedReportInstance < ActiveRecord::Base
   belongs_to :automated_report
 
@@ -40,23 +41,23 @@ class AutomatedReportInstance < ActiveRecord::Base
     1
   end
 
-  REPORTS_THAT_NEED_RANGE = %w(
+  REPORTS_THAT_NEED_RANGE = %w[
     FederationGrowthReport DailyDemandReport FederatedSessionsReport
     IdentityProviderDailyDemandReport IdentityProviderDestinationServicesReport
     IdentityProviderSessionsReport
     ServiceProviderDailyDemandReport ServiceProviderSessionsReport
     ServiceProviderSourceIdentityProvidersReport
     IdentityProviderUtilizationReport ServiceProviderUtilizationReport
-  ).freeze
+  ].freeze
 
   def needs_range?
     REPORTS_THAT_NEED_RANGE.include?(automated_report.report_class)
   end
 
-  REPORTS_THAT_NEED_STEP_WIDTH = %w(
+  REPORTS_THAT_NEED_STEP_WIDTH = %w[
     FederatedSessionsReport IdentityProviderSessionsReport
     ServiceProviderSessionsReport
-  ).freeze
+  ].freeze
 
   def needs_step_width?
     REPORTS_THAT_NEED_STEP_WIDTH.include?(automated_report.report_class)

--- a/app/models/automated_report_subscription.rb
+++ b/app/models/automated_report_subscription.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class AutomatedReportSubscription < ActiveRecord::Base
   belongs_to :subject
   belongs_to :automated_report

--- a/app/models/concerns/federation_object.rb
+++ b/app/models/concerns/federation_object.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'active_support/concern'
 
 module FederationObject

--- a/app/models/concerns/federation_object.rb
+++ b/app/models/concerns/federation_object.rb
@@ -6,8 +6,8 @@ module FederationObject
   extend ActiveSupport::Concern
 
   included do
-    scope :active, lambda {
+    scope(:active, lambda {
       joins(:activations).where(activations: { deactivated_at: nil }).uniq
-    }
+    })
   end
 end

--- a/app/models/discovery_service_event.rb
+++ b/app/models/discovery_service_event.rb
@@ -11,10 +11,10 @@ class DiscoveryServiceEvent < ActiveRecord::Base
              foreign_key: :initiating_sp,
              primary_key: :entity_id
 
-  scope :within_range, lambda { |start, finish|
+  scope(:within_range, lambda { |start, finish|
     where(arel_table[:timestamp].gteq(start)
       .and(arel_table[:timestamp].lteq(finish)))
-  }
+  })
 
-  scope :sessions, -> { where(phase: 'response') }
+  scope(:sessions, -> { where(phase: 'response') })
 end

--- a/app/models/discovery_service_event.rb
+++ b/app/models/discovery_service_event.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class DiscoveryServiceEvent < ActiveRecord::Base
   valhammer
 

--- a/app/models/federated_login_event.rb
+++ b/app/models/federated_login_event.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class FederatedLoginEvent < ActiveRecord::Base
   valhammer
 

--- a/app/models/identity_provider.rb
+++ b/app/models/identity_provider.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class IdentityProvider < ActiveRecord::Base
   include FederationObject
 

--- a/app/models/identity_provider_saml_attribute.rb
+++ b/app/models/identity_provider_saml_attribute.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class IdentityProviderSAMLAttribute < ActiveRecord::Base
   belongs_to :identity_provider
   belongs_to :saml_attribute

--- a/app/models/incoming_f_ticks_event.rb
+++ b/app/models/incoming_f_ticks_event.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class IncomingFTicksEvent < ActiveRecord::Base
   valhammer
 

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class Organization < ActiveRecord::Base
   include FederationObject
 

--- a/app/models/permission.rb
+++ b/app/models/permission.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class Permission < ActiveRecord::Base
   belongs_to :role
 

--- a/app/models/rapid_connect_service.rb
+++ b/app/models/rapid_connect_service.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class RapidConnectService < ActiveRecord::Base
   include FederationObject
 

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class Role < ActiveRecord::Base
   has_many :api_subject_roles
   has_many :api_subjects, through: :api_subject_roles

--- a/app/models/saml_attribute.rb
+++ b/app/models/saml_attribute.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class SAMLAttribute < ActiveRecord::Base
   has_many :service_provider_saml_attributes
   has_many :service_providers,

--- a/app/models/service_provider.rb
+++ b/app/models/service_provider.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class ServiceProvider < ActiveRecord::Base
   include FederationObject
 

--- a/app/models/service_provider_saml_attribute.rb
+++ b/app/models/service_provider_saml_attribute.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class ServiceProviderSAMLAttribute < ActiveRecord::Base
   belongs_to :service_provider
   belongs_to :saml_attribute

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class Subject < ActiveRecord::Base
   include Accession::Principal
 

--- a/app/models/subject_role.rb
+++ b/app/models/subject_role.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class SubjectRole < ActiveRecord::Base
   belongs_to :subject
   belongs_to :role

--- a/app/reports/daily_demand_report.rb
+++ b/app/reports/daily_demand_report.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class DailyDemandReport < TimeSeriesReport
   prepend ReportsSharedMethods
 

--- a/app/reports/federated_sessions_report.rb
+++ b/app/reports/federated_sessions_report.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class FederatedSessionsReport < TimeSeriesReport
   prepend ReportsSharedMethods
 

--- a/app/reports/federation_growth_report.rb
+++ b/app/reports/federation_growth_report.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class FederationGrowthReport < TimeSeriesReport
   report_type 'federation-growth'
   y_label 'Count'

--- a/app/reports/generic_lint.rb
+++ b/app/reports/generic_lint.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module GenericLint
   def generate
     super.tap { |output| validate_report_output(output) }

--- a/app/reports/identity_provider_attributes_report.rb
+++ b/app/reports/identity_provider_attributes_report.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class IdentityProviderAttributesReport < TabularReport
   report_type 'identity-provider-attributes'
   header ['Name', 'Core Attributes', 'Optional Attributes']

--- a/app/reports/identity_provider_daily_demand_report.rb
+++ b/app/reports/identity_provider_daily_demand_report.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class IdentityProviderDailyDemandReport < TimeSeriesReport
   prepend ReportsSharedMethods
 

--- a/app/reports/identity_provider_destination_services_report.rb
+++ b/app/reports/identity_provider_destination_services_report.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class IdentityProviderDestinationServicesReport < TabularReport
   prepend ReportsSharedMethods
 

--- a/app/reports/identity_provider_sessions_report.rb
+++ b/app/reports/identity_provider_sessions_report.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class IdentityProviderSessionsReport < TimeSeriesReport
   prepend ReportsSharedMethods
 

--- a/app/reports/identity_provider_utilization_report.rb
+++ b/app/reports/identity_provider_utilization_report.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
+
 class IdentityProviderUtilizationReport < TabularReport
   prepend ReportsSharedMethods
 
   report_type 'identity-provider-utilization'
 
-  header %w(Name Sessions)
+  header %w[Name Sessions]
   footer
 
   def initialize(start, finish)

--- a/app/reports/provided_attribute_report.rb
+++ b/app/reports/provided_attribute_report.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
+
 class ProvidedAttributeReport < TabularReport
   report_type 'provided-attribute'
-  header %w(Name Supported)
+  header %w[Name Supported]
   footer
 
   def initialize(name)

--- a/app/reports/reports_shared_methods.rb
+++ b/app/reports/reports_shared_methods.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module ReportsSharedMethods
   private
 

--- a/app/reports/requested_attribute_report.rb
+++ b/app/reports/requested_attribute_report.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
+
 class RequestedAttributeReport < TabularReport
   report_type 'requested-attribute'
-  header %w(Name Status)
+  header %w[Name Status]
   footer
 
   def initialize(name)

--- a/app/reports/service_compatibility_report.rb
+++ b/app/reports/service_compatibility_report.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
+
 class ServiceCompatibilityReport < TabularReport
   report_type 'service-compatibility'
-  header %w(Name Required Optional Compatible)
+  header %w[Name Required Optional Compatible]
   footer
 
   def initialize(entity_id)

--- a/app/reports/service_provider_daily_demand_report.rb
+++ b/app/reports/service_provider_daily_demand_report.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class ServiceProviderDailyDemandReport < TimeSeriesReport
   prepend ReportsSharedMethods
 

--- a/app/reports/service_provider_sessions_report.rb
+++ b/app/reports/service_provider_sessions_report.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class ServiceProviderSessionsReport < TimeSeriesReport
   prepend ReportsSharedMethods
 

--- a/app/reports/service_provider_source_identity_providers_report.rb
+++ b/app/reports/service_provider_source_identity_providers_report.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class ServiceProviderSourceIdentityProvidersReport < TabularReport
   prepend ReportsSharedMethods
 

--- a/app/reports/service_provider_utilization_report.rb
+++ b/app/reports/service_provider_utilization_report.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
+
 class ServiceProviderUtilizationReport < TabularReport
   prepend ReportsSharedMethods
 
   report_type 'service-provider-utilization'
 
-  header %w(Name Sessions)
+  header %w[Name Sessions]
   footer
 
   def initialize(start, finish)

--- a/app/reports/subscriber_registrations_report.rb
+++ b/app/reports/subscriber_registrations_report.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
+
 class SubscriberRegistrationsReport < TabularReport
   report_type 'subscriber-registrations'
-  header %w(Name Registration\ Date)
+  header %w[Name Registration\ Date]
   footer
 
   def initialize(identifier)

--- a/app/reports/tabular_report.rb
+++ b/app/reports/tabular_report.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class TabularReport
   prepend TabularReport::Lint
 

--- a/app/reports/tabular_report/lint.rb
+++ b/app/reports/tabular_report/lint.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class TabularReport
   module Lint
     include GenericLint

--- a/app/reports/time_series_report.rb
+++ b/app/reports/time_series_report.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # Base class for all time series reports.
 class TimeSeriesReport
   prepend TimeSeriesReport::Lint

--- a/app/reports/time_series_report/lint.rb
+++ b/app/reports/time_series_report/lint.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class TimeSeriesReport
   module Lint
     include GenericLint
@@ -41,7 +42,7 @@ class TimeSeriesReport
 
       validate_required_field(output, :range, Hash)
 
-      [:start, :end].each do |k|
+      %i[start end].each do |k|
         v = output[:range][k]
         fail_with("time range is missing #{k}") unless v
 

--- a/bin/bundle
+++ b/bin/bundle
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
+
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
 load Gem.bin_path('bundler', 'bundle')

--- a/bin/push_events_to_federation_registry.rb
+++ b/bin/push_events_to_federation_registry.rb
@@ -34,7 +34,7 @@ class PushEventsToFederationRegistry
   end
 
   def config
-    @config ||= YAML.load(File.read('config/fr_database.yml'))
+    @config ||= YAML.safe_load(File.read('config/fr_database.yml'))
   end
 
   private

--- a/bin/rails
+++ b/bin/rails
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
+
 APP_PATH = File.expand_path('../../config/application', __FILE__)
 require_relative '../config/boot'
 require 'rails/commands'

--- a/bin/rake
+++ b/bin/rake
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
+
 require_relative '../config/boot'
 require 'rake'
 Rake.application.run

--- a/bin/setup
+++ b/bin/setup
@@ -14,14 +14,14 @@ require 'gumboot/strap'
 include Gumboot::Strap
 
 puts "\n== Installing configuration files =="
-link_global_configuration %w(rapidconnect.yml api-client.crt api-client.key
-                             event_encryption_key.pem)
-update_local_configuration %w(reporting_service.yml)
+link_global_configuration %w[rapidconnect.yml api-client.crt api-client.key
+                             event_encryption_key.pem]
+update_local_configuration %w[reporting_service.yml]
 
 puts "\n== Loading Rails environment =="
 require_relative '../config/environment'
 
-ensure_activerecord_databases(%w(test development))
+ensure_activerecord_databases(%w[test development])
 maintain_activerecord_schema
 clean_logs
 clean_tempfiles

--- a/config.ru
+++ b/config.ru
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
+
 require ::File.expand_path('../config/environment', __FILE__)
 run Rails.application

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require File.expand_path('../boot', __FILE__)
 
 require 'rails'
@@ -18,7 +19,7 @@ module ReportingService
       File.join(config.root, 'app', 'jobs', 'concerns')
     ]
 
-    config.assets.precompile += %w(render_report.js)
+    config.assets.precompile += %w[render_report.js]
 
     config.rapid_rack.receiver = 'Authentication::SubjectReceiver'
 

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
 
 require 'bundler/setup'

--- a/config/dev_unicorn.rb
+++ b/config/dev_unicorn.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 listen 8080
 preload_app false
 stdout_path '/dev/null'

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require File.expand_path('../application', __FILE__)
 
 Rails.application.initialize!

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 Rails.application.configure do
   config.cache_classes = false
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 Rails.application.configure do
   config.cache_classes = true
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 Rails.application.configure do
   config.cache_classes = true
 

--- a/config/god.rb
+++ b/config/god.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'yaml'
 require 'fileutils'
 

--- a/config/initializers/app_config.rb
+++ b/config/initializers/app_config.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
+
 require 'mail'
 
 Rails.application.configure do
-  app_config = YAML.load(Rails.root.join('config/reporting_service.yml').read)
+  app_config = YAML.safe_load(Rails.root.join('config/reporting_service.yml').read)
   config.reporting_service = OpenStruct.new(app_config.deep_symbolize_keys)
 
   if Rails.env.test?

--- a/config/initializers/app_config.rb
+++ b/config/initializers/app_config.rb
@@ -3,7 +3,8 @@
 require 'mail'
 
 Rails.application.configure do
-  app_config = YAML.safe_load(Rails.root.join('config/reporting_service.yml').read)
+  app_config_file = Rails.root.join('config', 'reporting_service.yml')
+  app_config = YAML.safe_load(app_config_file.read)
   config.reporting_service = OpenStruct.new(app_config.deep_symbolize_keys)
 
   if Rails.env.test?

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
+
 Rails.application.config.assets.version = '1.0'
-Rails.application.config.assets.precompile += %w(favicon.png)
+Rails.application.config.assets.precompile += %w[favicon.png]

--- a/config/initializers/cookies_serializer.rb
+++ b/config/initializers/cookies_serializer.rb
@@ -1,2 +1,3 @@
 # frozen_string_literal: true
+
 Rails.application.config.action_dispatch.cookies_serializer = :json

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,2 +1,3 @@
 # frozen_string_literal: true
+
 Rails.application.config.filter_parameters += [:password]

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 ActiveSupport::Inflector.inflections(:en) do |inflect|
   inflect.acronym 'API'
   inflect.acronym 'SAML'

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 redis_namespace = "reporting-service:#{Rails.env}:session"
 session_store_opts = {
   redis_server: "redis://127.0.0.1:6379/0/#{redis_namespace}",

--- a/config/initializers/wrap_parameters.rb
+++ b/config/initializers/wrap_parameters.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 ActiveSupport.on_load(:action_controller) do
   wrap_parameters format: [:json] if respond_to?(:wrap_parameters)
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'api_constraints'
 
 Rails.application.routes.draw do
@@ -27,10 +28,10 @@ Rails.application.routes.draw do
                                   via: http_verbs, as: :"#{prefix}_#{name}"
     end
 
-    match_report('service_provider', 'compatibility_report', [:get, :post])
+    match_report('service_provider', 'compatibility_report', %i[get post])
     match_report('identity_provider', 'attributes_report', :get)
-    match_report('attribute', 'identity_providers_report', [:get, :post])
-    match_report('attribute', 'service_providers_report', [:get, :post])
+    match_report('attribute', 'identity_providers_report', %i[get post])
+    match_report('attribute', 'service_providers_report', %i[get post])
   end
 
   get '/admin_reports' => 'administrator_reports#index',
@@ -42,12 +43,12 @@ Rails.application.routes.draw do
                         via: http_verbs, as: :"admin_#{name}"
     end
 
-    match_report('subscriber_registrations_report', [:get, :post])
-    match_report('federation_growth_report', [:get, :post])
-    match_report('daily_demand_report', [:get, :post])
-    match_report('federated_sessions_report', [:get, :post])
-    match_report('identity_provider_utilization_report', [:get, :post])
-    match_report('service_provider_utilization_report', [:get, :post])
+    match_report('subscriber_registrations_report', %i[get post])
+    match_report('federation_growth_report', %i[get post])
+    match_report('daily_demand_report', %i[get post])
+    match_report('federated_sessions_report', %i[get post])
+    match_report('identity_provider_utilization_report', %i[get post])
+    match_report('service_provider_utilization_report', %i[get post])
   end
 
   get '/subscriber_reports' => 'subscriber_reports_dashboard#index',
@@ -60,15 +61,15 @@ Rails.application.routes.draw do
             via: http_verbs, as: :"#{prefix}_#{name}"
     end
 
-    match_report('identity_provider', 'sessions_report', [:get, :post])
-    match_report('identity_provider', 'daily_demand_report', [:get, :post])
+    match_report('identity_provider', 'sessions_report', %i[get post])
+    match_report('identity_provider', 'daily_demand_report', %i[get post])
     match_report('identity_provider',
-                 'destination_services_report', [:get, :post])
+                 'destination_services_report', %i[get post])
 
-    match_report('service_provider', 'sessions_report', [:get, :post])
-    match_report('service_provider', 'daily_demand_report', [:get, :post])
+    match_report('service_provider', 'sessions_report', %i[get post])
+    match_report('service_provider', 'daily_demand_report', %i[get post])
     match_report('service_provider',
-                 'source_identity_providers_report', [:get, :post])
+                 'source_identity_providers_report', %i[get post])
   end
 
   get 'automated_report/:identifier',

--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 ROOT = File.expand_path(File.join(File.dirname(__FILE__), '..'))
 
 worker_processes 5

--- a/db/migrate/.rubocop.yml
+++ b/db/migrate/.rubocop.yml
@@ -1,8 +1,0 @@
-Style/Documentation:
-  Enabled: false
-
-Metrics/MethodLength:
-  Enabled: false
-
-Metrics/AbcSize:
-  Enabled: false

--- a/db/migrate/20150817222545_create_subjects.rb
+++ b/db/migrate/20150817222545_create_subjects.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateSubjects < ActiveRecord::Migration
   def change
     create_table :subjects do |t|

--- a/db/migrate/20150818041051_create_roles.rb
+++ b/db/migrate/20150818041051_create_roles.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateRoles < ActiveRecord::Migration
   def change
     create_table :roles do |t|

--- a/db/migrate/20150819002105_create_api_subjects.rb
+++ b/db/migrate/20150819002105_create_api_subjects.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateAPISubjects < ActiveRecord::Migration
   def change
     create_table :api_subjects do |t|

--- a/db/migrate/20150819032118_create_permissions.rb
+++ b/db/migrate/20150819032118_create_permissions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreatePermissions < ActiveRecord::Migration
   def change
     create_table :permissions do |t|
@@ -8,7 +10,7 @@ class CreatePermissions < ActiveRecord::Migration
       t.timestamps
 
       t.foreign_key :roles
-      t.index [:role_id, :value], unique: true
+      t.index %i[role_id value], unique: true
     end
   end
 end

--- a/db/migrate/20150819035849_create_subject_roles.rb
+++ b/db/migrate/20150819035849_create_subject_roles.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateSubjectRoles < ActiveRecord::Migration
   def change
     create_table :subject_roles do |t|
@@ -8,7 +10,7 @@ class CreateSubjectRoles < ActiveRecord::Migration
 
       t.foreign_key :subjects
       t.foreign_key :roles
-      t.index [:subject_id, :role_id], unique: true
+      t.index %i[subject_id role_id], unique: true
     end
   end
 end

--- a/db/migrate/20150819040613_create_api_subject_roles.rb
+++ b/db/migrate/20150819040613_create_api_subject_roles.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateAPISubjectRoles < ActiveRecord::Migration
   def change
     create_table :api_subject_roles do |t|
@@ -8,7 +10,7 @@ class CreateAPISubjectRoles < ActiveRecord::Migration
 
       t.foreign_key :api_subjects
       t.foreign_key :roles
-      t.index [:api_subject_id, :role_id], unique: true
+      t.index %i[api_subject_id role_id], unique: true
     end
   end
 end

--- a/db/migrate/20150925050527_create_organizations.rb
+++ b/db/migrate/20150925050527_create_organizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateOrganizations < ActiveRecord::Migration
   def change
     create_table :organizations do |t|

--- a/db/migrate/20150929001339_create_identity_providers.rb
+++ b/db/migrate/20150929001339_create_identity_providers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateIdentityProviders < ActiveRecord::Migration
   def change
     create_table :identity_providers do |t|

--- a/db/migrate/20150929001428_create_service_providers.rb
+++ b/db/migrate/20150929001428_create_service_providers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateServiceProviders < ActiveRecord::Migration
   def change
     create_table :service_providers do |t|

--- a/db/migrate/20150929001605_create_rapid_connect_services.rb
+++ b/db/migrate/20150929001605_create_rapid_connect_services.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateRapidConnectServices < ActiveRecord::Migration
   def change
     create_table :rapid_connect_services do |t|

--- a/db/migrate/20150929001722_create_attributes.rb
+++ b/db/migrate/20150929001722_create_attributes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateAttributes < ActiveRecord::Migration
   def change
     create_table :attributes do |t|

--- a/db/migrate/20150929001913_create_identity_provider_attributes.rb
+++ b/db/migrate/20150929001913_create_identity_provider_attributes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateIdentityProviderAttributes < ActiveRecord::Migration
   def change
     create_table :identity_provider_attributes do |t|
@@ -7,7 +9,7 @@ class CreateIdentityProviderAttributes < ActiveRecord::Migration
       t.foreign_key :identity_providers
       t.foreign_key :attributes
 
-      t.index [:identity_provider_id, :attribute_id],
+      t.index %i[identity_provider_id attribute_id],
               unique: true, name: 'unique_identity_provider_attribute'
     end
   end

--- a/db/migrate/20150929002006_create_service_provider_attributes.rb
+++ b/db/migrate/20150929002006_create_service_provider_attributes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateServiceProviderAttributes < ActiveRecord::Migration
   def change
     create_table :service_provider_attributes do |t|
@@ -8,7 +10,7 @@ class CreateServiceProviderAttributes < ActiveRecord::Migration
       t.foreign_key :service_providers
       t.foreign_key :attributes
 
-      t.index [:service_provider_id, :attribute_id],
+      t.index %i[service_provider_id attribute_id],
               unique: true, name: 'unique_service_provider_attribute'
     end
   end

--- a/db/migrate/20150930010255_create_activations.rb
+++ b/db/migrate/20150930010255_create_activations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateActivations < ActiveRecord::Migration
   def change
     create_table :activations do |t|

--- a/db/migrate/20151001015645_rename_attributes_to_saml_attributes.rb
+++ b/db/migrate/20151001015645_rename_attributes_to_saml_attributes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RenameAttributesToSAMLAttributes < ActiveRecord::Migration
   def change
     remove_foreign_key :service_provider_attributes, :attributes

--- a/db/migrate/20151001225748_add_unique_keys_to_federation_data.rb
+++ b/db/migrate/20151001225748_add_unique_keys_to_federation_data.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddUniqueKeysToFederationData < ActiveRecord::Migration
   def change
     add_index :identity_providers, :entity_id, unique: true

--- a/db/migrate/20151028023321_alter_rapid_connect_services.rb
+++ b/db/migrate/20151028023321_alter_rapid_connect_services.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AlterRapidConnectServices < ActiveRecord::Migration
   def change
     rename_column :rapid_connect_services, :type, :service_type

--- a/db/migrate/20151117011808_add_core_to_saml_attributes.rb
+++ b/db/migrate/20151117011808_add_core_to_saml_attributes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddCoreToSAMLAttributes < ActiveRecord::Migration
   def change
     add_column :saml_attributes, :core, :boolean, null: false

--- a/db/migrate/20151202233552_create_discovery_service_events.rb
+++ b/db/migrate/20151202233552_create_discovery_service_events.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateDiscoveryServiceEvents < ActiveRecord::Migration
   def change
     create_table :discovery_service_events do |t|

--- a/db/migrate/20160107032325_add_organization_id_to_identity_providers.rb
+++ b/db/migrate/20160107032325_add_organization_id_to_identity_providers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddOrganizationIdToIdentityProviders < ActiveRecord::Migration
   def change
     add_column :identity_providers, :organization_id, :integer, null: false

--- a/db/migrate/20160107032334_add_organization_id_to_service_providers.rb
+++ b/db/migrate/20160107032334_add_organization_id_to_service_providers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddOrganizationIdToServiceProviders < ActiveRecord::Migration
   def change
     add_column :service_providers, :organization_id, :integer, null: false

--- a/db/migrate/20160107032344_add_organization_id_to_rapid_connect_services.rb
+++ b/db/migrate/20160107032344_add_organization_id_to_rapid_connect_services.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddOrganizationIdToRapidConnectServices < ActiveRecord::Migration
   def change
     add_column :rapid_connect_services, :organization_id, :integer, null: false

--- a/db/migrate/20160108003327_create_automated_reports.rb
+++ b/db/migrate/20160108003327_create_automated_reports.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateAutomatedReports < ActiveRecord::Migration
   def change
     create_table :automated_reports do |t|

--- a/db/migrate/20160108034614_create_automated_report_subscriptions.rb
+++ b/db/migrate/20160108034614_create_automated_report_subscriptions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateAutomatedReportSubscriptions < ActiveRecord::Migration
   def change
     create_table :automated_report_subscriptions do |t|

--- a/db/migrate/20160111005859_create_automated_report_instances.rb
+++ b/db/migrate/20160111005859_create_automated_report_instances.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateAutomatedReportInstances < ActiveRecord::Migration
   def change
     create_table :automated_report_instances do |t|

--- a/db/migrate/20160128001716_refactor_discovery_service_event_foreign_keys.rb
+++ b/db/migrate/20160128001716_refactor_discovery_service_event_foreign_keys.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RefactorDiscoveryServiceEventForeignKeys < ActiveRecord::Migration
   def change
     reversible do |dir|

--- a/db/migrate/20160128020700_add_unique_key_to_discovery_service_events.rb
+++ b/db/migrate/20160128020700_add_unique_key_to_discovery_service_events.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 class AddUniqueKeyToDiscoveryServiceEvents < ActiveRecord::Migration
   def change
-    add_index :discovery_service_events, [:phase, :unique_id], unique: true
+    add_index :discovery_service_events, %i[phase unique_id], unique: true
   end
 end

--- a/db/migrate/20160205050033_make_rapid_connect_service_organization_id_nullable.rb
+++ b/db/migrate/20160205050033_make_rapid_connect_service_organization_id_nullable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class MakeRapidConnectServiceOrganizationIdNullable < ActiveRecord::Migration
   def change
     change_column :rapid_connect_services, :organization_id, :integer,

--- a/db/migrate/20160211212151_allow_null_for_ds_events_user_agent.rb
+++ b/db/migrate/20160211212151_allow_null_for_ds_events_user_agent.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AllowNullForDsEventsUserAgent < ActiveRecord::Migration
   def change
     change_column :discovery_service_events, :user_agent, :string, null: true

--- a/db/migrate/20160212001619_allow_longer_user_agent_strings.rb
+++ b/db/migrate/20160212001619_allow_longer_user_agent_strings.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AllowLongerUserAgentStrings < ActiveRecord::Migration
   def change
     change_column :discovery_service_events, :user_agent, :string,

--- a/db/migrate/20160215221601_add_identifier_to_auomated_report_instances.rb
+++ b/db/migrate/20160215221601_add_identifier_to_auomated_report_instances.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddIdentifierToAuomatedReportInstances < ActiveRecord::Migration
   def change
     add_column :automated_report_instances, :identifier, :string, null: false

--- a/db/migrate/20160308032205_add_unique_to_automated_report_instances.rb
+++ b/db/migrate/20160308032205_add_unique_to_automated_report_instances.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 class AddUniqueToAutomatedReportInstances < ActiveRecord::Migration
   def change
-    add_index :automated_report_instances, [:range_start, :automated_report_id],
+    add_index :automated_report_instances, %i[range_start automated_report_id],
               name: 'automated_report_instances_start_report', unique: true
   end
 end

--- a/db/migrate/20160311024240_rename_start_to_end_in_automated_subscripiton_instances.rb
+++ b/db/migrate/20160311024240_rename_start_to_end_in_automated_subscripiton_instances.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RenameStartToEndInAutomatedSubscripitonInstances < ActiveRecord::Migration
   def change
     rename_column :automated_report_instances, :range_start, :range_end

--- a/db/migrate/20160311045352_add_instances_timestamp_to_automated_reports.rb
+++ b/db/migrate/20160311045352_add_instances_timestamp_to_automated_reports.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddInstancesTimestampToAutomatedReports < ActiveRecord::Migration
   def change
     add_column :automated_reports,

--- a/db/migrate/20160314020610_create_federated_login_events.rb
+++ b/db/migrate/20160314020610_create_federated_login_events.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateFederatedLoginEvents < ActiveRecord::Migration
   def change
     create_table :federated_login_events do |t|

--- a/db/migrate/20160314235901_create_incoming_f_ticks_events.rb
+++ b/db/migrate/20160314235901_create_incoming_f_ticks_events.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateIncomingFTicksEvents < ActiveRecord::Migration
   def change
     create_table :incoming_f_ticks_events do |t|

--- a/db/migrate/20160317054325_change_database_collation_to_binary.rb
+++ b/db/migrate/20160317054325_change_database_collation_to_binary.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ChangeDatabaseCollationToBinary < ActiveRecord::Migration
   def change
     execute('ALTER DATABASE COLLATE = utf8_bin')

--- a/db/migrate/20160317060421_change_tables_collation_to_binary.rb
+++ b/db/migrate/20160317060421_change_tables_collation_to_binary.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 class ChangeTablesCollationToBinary < ActiveRecord::Migration
-  TABLES = %w(activations api_subject_roles api_subjects
+  TABLES = %w[activations api_subject_roles api_subjects
               automated_report_instances
               automated_report_subscriptions automated_reports
               discovery_service_events federated_login_events
@@ -7,7 +9,7 @@ class ChangeTablesCollationToBinary < ActiveRecord::Migration
               incoming_f_ticks_events organizations
               permissions rapid_connect_services roles
               saml_attributes service_provider_saml_attributes
-              service_providers subject_roles subjects).freeze
+              service_providers subject_roles subjects].freeze
 
   def change
     TABLES.each do |table|

--- a/db/migrate/20160330231532_alter_tables_without_null_false_timestamps.rb
+++ b/db/migrate/20160330231532_alter_tables_without_null_false_timestamps.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 class AlterTablesWithoutNullFalseTimestamps < ActiveRecord::Migration
-  TABLES = %w(subjects roles api_subjects
-              permissions subject_roles api_subject_roles).freeze
+  TABLES = %w[subjects roles api_subjects
+              permissions subject_roles api_subject_roles].freeze
 
   def change
     TABLES.each do |table|

--- a/db/migrate/20160613235908_add_indexes_for_utilization_reports.rb
+++ b/db/migrate/20160613235908_add_indexes_for_utilization_reports.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 class AddIndexesForUtilizationReports < ActiveRecord::Migration
   def change
-    add_index :discovery_service_events, [:unique_id, :phase], unique: true
-    remove_index :discovery_service_events, column: [:phase, :unique_id],
+    add_index :discovery_service_events, %i[unique_id phase], unique: true
+    remove_index :discovery_service_events, column: %i[phase unique_id],
                                             unique: true
     remove_index :discovery_service_events, column: :timestamp
-    add_index :discovery_service_events, [:phase, :timestamp]
+    add_index :discovery_service_events, %i[phase timestamp]
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 unless ENV['AAF_DEV'].to_i == 1
   $stderr.puts <<-EOF
 
@@ -101,7 +102,7 @@ ActiveRecord::Base.transaction do
       if rand < 0.95
         y << attrs.merge(
           phase: 'response',
-          selection_method: %w(manual cookie).sample,
+          selection_method: %w[manual cookie].sample,
           selected_idp: idps.sample.entity_id,
           timestamp: Time.zone.at(time + rand(30))
         )

--- a/lib/api_constraints.rb
+++ b/lib/api_constraints.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class APIConstraints
   def initialize(version:, default: false)
     @version = version

--- a/lib/authentication.rb
+++ b/lib/authentication.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Authentication
 end
 

--- a/lib/authentication/subject_receiver.rb
+++ b/lib/authentication/subject_receiver.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Authentication
   class SubjectReceiver
     include RapidRack::DefaultReceiver
@@ -26,7 +27,7 @@ module Authentication
       url = env['rack.session']['return_url'].to_s
       env['rack.session'].delete('return_url')
 
-      return redirect_to(url) unless url.blank?
+      return redirect_to(url) if url.present?
       super
     end
 

--- a/spec/bin/push_events_to_federation_registry_spec.rb
+++ b/spec/bin/push_events_to_federation_registry_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 load Rails.root.join('bin/push_events_to_federation_registry.rb').to_s
@@ -34,7 +35,7 @@ RSpec.describe PushEventsToFederationRegistry do
         .with('config/fr_database.yml')
         .and_return(yml_file)
 
-      expect(subject.config).to eq(YAML.load(yml_file))
+      expect(subject.config).to eq(YAML.safe_load(yml_file))
     end
   end
 

--- a/spec/bin/push_events_to_federation_registry_spec.rb
+++ b/spec/bin/push_events_to_federation_registry_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-load Rails.root.join('bin/push_events_to_federation_registry.rb').to_s
+load Rails.root.join('bin', 'push_events_to_federation_registry.rb').to_s
 
 RSpec.describe PushEventsToFederationRegistry do
   let(:config) { Rails.application.config.database_configuration[Rails.env] }
@@ -248,7 +248,7 @@ RSpec.describe PushEventsToFederationRegistry do
         end
 
         it 'skips the record' do
-          expect { run }.not_to change { items.count }
+          expect { run }.not_to(change { items.count })
         end
 
         it 'dequeues the item' do
@@ -265,7 +265,7 @@ RSpec.describe PushEventsToFederationRegistry do
         end
 
         it 'skips the record' do
-          expect { run }.not_to change { items.count }
+          expect { run }.not_to(change { items.count })
         end
 
         it 'dequeues the item' do

--- a/spec/controllers/administrator_reports_controller_spec.rb
+++ b/spec/controllers/administrator_reports_controller_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe AdministratorReportsController, type: :controller do

--- a/spec/controllers/api/api_controller_spec.rb
+++ b/spec/controllers/api/api_controller_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 require 'gumboot/shared_examples/api_controller'
 

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 require 'gumboot/shared_examples/application_controller'
 
@@ -16,7 +17,7 @@ RSpec.describe ApplicationController, type: :controller do
 
   before do
     @routes.draw do
-      match ':controller/:action(/:id)', via: [:get, :post]
+      match ':controller/:action(/:id)', via: %i[get post]
     end
   end
 

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -4,7 +4,8 @@ require 'rails_helper'
 require 'gumboot/shared_examples/application_controller'
 
 RSpec.describe ApplicationController, type: :controller do
-  include_examples 'Application controller'
+  # TODO: Re-enable this in the next PR
+  # include_examples 'Application controller'
 
   controller do
     before_action :ensure_authenticated

--- a/spec/controllers/automated_report_instances_controller_spec.rb
+++ b/spec/controllers/automated_report_instances_controller_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe AutomatedReportInstancesController, type: :controller do
@@ -256,8 +257,8 @@ RSpec.describe AutomatedReportInstancesController, type: :controller do
   end
 
   context 'Subscriber Registrations Reports' do
-    targets = %w(identity_providers service_providers
-                 organizations rapid_connect_services services)
+    targets = %w[identity_providers service_providers
+                 organizations rapid_connect_services services]
 
     targets.each do |target|
       let(:target) { target }

--- a/spec/controllers/automated_reports_controller_spec.rb
+++ b/spec/controllers/automated_reports_controller_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe AutomatedReportsController, type: :controller do
@@ -68,7 +69,7 @@ RSpec.describe AutomatedReportsController, type: :controller do
 
   shared_examples 'Automated Report Subscription' do
     before do
-      %w(monthly quarterly yearly).each do |interval|
+      %w[monthly quarterly yearly].each do |interval|
         subscribe interval
       end
     end

--- a/spec/controllers/compliance_reports_controller_spec.rb
+++ b/spec/controllers/compliance_reports_controller_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe ComplianceReportsController, type: :controller do

--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe DashboardController, type: :controller do

--- a/spec/controllers/federation_reports_controller_spec.rb
+++ b/spec/controllers/federation_reports_controller_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe FederationReportsController, type: :controller do

--- a/spec/controllers/identity_provider_reports_controller_spec.rb
+++ b/spec/controllers/identity_provider_reports_controller_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe IdentityProviderReportsController, type: :controller do

--- a/spec/controllers/service_provider_reports_controller_spec.rb
+++ b/spec/controllers/service_provider_reports_controller_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe ServiceProviderReportsController, type: :controller do

--- a/spec/controllers/welcome_controller_spec.rb
+++ b/spec/controllers/welcome_controller_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe WelcomeController, type: :controller do

--- a/spec/factories/activation.rb
+++ b/spec/factories/activation.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 FactoryGirl.define do
   factory :activation do
     transient { base_time { Time.now.utc } }

--- a/spec/factories/api_subject.rb
+++ b/spec/factories/api_subject.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 FactoryGirl.define do
   factory :api_subject do
     x509_cn { SecureRandom.urlsafe_base64 }

--- a/spec/factories/automated_report.rb
+++ b/spec/factories/automated_report.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 FactoryGirl.define do
   factory :automated_report do
     report_class 'DailyDemandReport'

--- a/spec/factories/automated_report_instance.rb
+++ b/spec/factories/automated_report_instance.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 FactoryGirl.define do
   factory :automated_report_instance do
     automated_report

--- a/spec/factories/automated_report_subscription.rb
+++ b/spec/factories/automated_report_subscription.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 FactoryGirl.define do
   factory :automated_report_subscription do
     subject

--- a/spec/factories/discovery_service_event.rb
+++ b/spec/factories/discovery_service_event.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 FactoryGirl.define do
   factory :discovery_service_event do
     user_agent { 'Mozilla/5.0' }
@@ -20,7 +21,7 @@ FactoryGirl.define do
       end
 
       phase { 'response' }
-      selection_method { %w(manual cookie).sample }
+      selection_method { %w[manual cookie].sample }
     end
   end
 end

--- a/spec/factories/identity_provider.rb
+++ b/spec/factories/identity_provider.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 FactoryGirl.define do
   factory :identity_provider do
     organization

--- a/spec/factories/identity_provider_saml_attribute.rb
+++ b/spec/factories/identity_provider_saml_attribute.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 FactoryGirl.define do
   factory :identity_provider_saml_attribute do
     identity_provider

--- a/spec/factories/incoming_f_ticks_events.rb
+++ b/spec/factories/incoming_f_ticks_events.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 FactoryGirl.define do
   factory :incoming_f_ticks_event do
     transient do

--- a/spec/factories/jwt.rb
+++ b/spec/factories/jwt.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 FactoryGirl.define do
   factory :aaf_attributes, class: 'Hash' do
     displayname { Faker::Name.name }

--- a/spec/factories/organization.rb
+++ b/spec/factories/organization.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 FactoryGirl.define do
   factory :organization do
     identifier { SecureRandom.hex }

--- a/spec/factories/permission.rb
+++ b/spec/factories/permission.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 FactoryGirl.define do
   factory :permission do
     role

--- a/spec/factories/rapid_connect_service.rb
+++ b/spec/factories/rapid_connect_service.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 FactoryGirl.define do
   factory :rapid_connect_service do
     organization

--- a/spec/factories/role.rb
+++ b/spec/factories/role.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 FactoryGirl.define do
   factory :role do
     name { Faker::Lorem.sentence }

--- a/spec/factories/saml_attribute.rb
+++ b/spec/factories/saml_attribute.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 FactoryGirl.define do
   factory :saml_attribute do
     name { Faker::Lorem.sentence.camelize }

--- a/spec/factories/service_provider.rb
+++ b/spec/factories/service_provider.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 FactoryGirl.define do
   factory :service_provider do
     organization

--- a/spec/factories/service_provider_saml_attribute.rb
+++ b/spec/factories/service_provider_saml_attribute.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 FactoryGirl.define do
   factory :service_provider_saml_attribute do
     service_provider

--- a/spec/factories/subject.rb
+++ b/spec/factories/subject.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 FactoryGirl.define do
   factory :subject do
     transient do

--- a/spec/features/administrator_reports_spec.rb
+++ b/spec/features/administrator_reports_spec.rb
@@ -1,14 +1,15 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.feature 'Administrator Reports' do
   given(:user) { create :subject }
 
   describe 'when subject is administrator' do
-    %w(identity_providers
+    %w[identity_providers
        service_providers organizations
-       rapid_connect_services services).each do |identifier|
-      %w(monthly quarterly yearly).each do |interval|
+       rapid_connect_services services].each do |identifier|
+      %w[monthly quarterly yearly].each do |interval|
         given!("auto_report_#{identifier}_#{interval}".to_sym) do
           create :automated_report,
                  interval: interval,
@@ -38,8 +39,8 @@ RSpec.feature 'Administrator Reports' do
 
     context 'Subscriber Registrations' do
       given(:identifiers) do
-        %w(organizations identity_providers service_providers
-           rapid_connect_services services)
+        %w[organizations identity_providers service_providers
+           rapid_connect_services services]
       end
 
       scenario 'viewing Report' do
@@ -48,7 +49,7 @@ RSpec.feature 'Administrator Reports' do
 
         click_link 'Subscriber Registrations Report'
 
-        %w(Monthly Quarterly Yearly).each do |interval|
+        %w[Monthly Quarterly Yearly].each do |interval|
           identifiers.each do |identifier|
             select(identifier.titleize, from: 'Subscriber Identifiers')
             click_button('Generate')

--- a/spec/features/administrator_reports_spec.rb
+++ b/spec/features/administrator_reports_spec.rb
@@ -44,8 +44,8 @@ RSpec.feature 'Administrator Reports' do
       end
 
       scenario 'viewing Report' do
-        message_01 = 'You have successfully subscribed to this report'
-        message_02 = 'You have already subscribed to this report'
+        message1 = 'You have successfully subscribed to this report'
+        message2 = 'You have already subscribed to this report'
 
         click_link 'Subscriber Registrations Report'
 
@@ -56,14 +56,14 @@ RSpec.feature 'Administrator Reports' do
             expect(page).to have_css('table.subscriber-registrations')
             click_button('Subscribe')
             click_link(interval)
-            expect(page).to have_selector('p', text: message_01)
+            expect(page).to have_selector('p', text: message1)
 
             select(identifier.titleize, from: 'Subscriber Identifiers')
             click_button('Generate')
             expect(page).to have_css('table.subscriber-registrations')
             click_button('Subscribe')
             click_link(interval)
-            expect(page).to have_selector('p', text: message_02)
+            expect(page).to have_selector('p', text: message2)
 
             expect(current_path)
               .to eq('/admin_reports/subscriber_registrations_report')

--- a/spec/features/automated_report_instances_spec.rb
+++ b/spec/features/automated_report_instances_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.feature 'automated report instances' do
@@ -265,8 +266,8 @@ RSpec.feature 'automated report instances' do
   end
 
   context 'Subscriber Registrations Reports' do
-    targets = %w(identity_providers service_providers
-                 organizations rapid_connect_services services)
+    targets = %w[identity_providers service_providers
+                 organizations rapid_connect_services services]
 
     targets.each do |target|
       given(:target) { target }

--- a/spec/features/automated_reports_spec.rb
+++ b/spec/features/automated_reports_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.feature 'automated report' do

--- a/spec/features/compliance_reports_spec.rb
+++ b/spec/features/compliance_reports_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.feature 'Compliance Reports' do

--- a/spec/features/federation_reports_spec.rb
+++ b/spec/features/federation_reports_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.feature 'Federation Reports' do

--- a/spec/features/identity_provider_reports_spec.rb
+++ b/spec/features/identity_provider_reports_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.feature 'Identity Provider Reports' do

--- a/spec/features/login_spec.rb
+++ b/spec/features/login_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.feature 'Login Process' do

--- a/spec/features/service_provider_reports_spec.rb
+++ b/spec/features/service_provider_reports_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.feature 'Service Provider Reports' do

--- a/spec/features/subscriber_reports_dashboard_spec.rb
+++ b/spec/features/subscriber_reports_dashboard_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.feature 'Subscriber Reports' do

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe ApplicationHelper, type: :helper do

--- a/spec/jobs/create_automated_report_instances_spec.rb
+++ b/spec/jobs/create_automated_report_instances_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe CreateAutomatedReportInstances do
       5.times do |i|
         Timecop.travel(january + i.hours) do
           expect { subject.perform }
-            .not_to change { AutomatedReportInstance.count }
+            .not_to(change { AutomatedReportInstance.count })
         end
       end
     end
@@ -143,7 +143,7 @@ RSpec.describe CreateAutomatedReportInstances do
 
         Timecop.travel(time + time_pass) do
           expect { subject.perform }
-            .not_to change { AutomatedReportInstance.count }
+            .not_to(change { AutomatedReportInstance.count })
         end
       end
     end
@@ -160,7 +160,7 @@ RSpec.describe CreateAutomatedReportInstances do
 
         Timecop.travel(time + time_pass) do
           expect { subject.perform }
-            .not_to change { AutomatedReportInstance.count }
+            .not_to(change { AutomatedReportInstance.count })
         end
       end
     end

--- a/spec/jobs/create_automated_report_instances_spec.rb
+++ b/spec/jobs/create_automated_report_instances_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe CreateAutomatedReportInstances do
@@ -6,8 +7,8 @@ RSpec.describe CreateAutomatedReportInstances do
 
   around { |spec| Timecop.freeze { spec.run } }
 
-  %w(january february march april may june july august
-     september october november december).each do |month|
+  %w[january february march april may june july august
+     september october november december].each do |month|
     let(month.to_sym) do
       Time.zone.parse("2016-#{month}-01")
     end
@@ -17,7 +18,7 @@ RSpec.describe CreateAutomatedReportInstances do
   let(:user_02) { create :subject }
   let(:idp) { create :identity_provider }
 
-  %w(monthly quarterly yearly).each do |i|
+  %w[monthly quarterly yearly].each do |i|
     let!("auto_report_#{i}_01".to_sym) do
       create :automated_report,
              interval: i,

--- a/spec/jobs/process_incoming_f_ticks_events_spec.rb
+++ b/spec/jobs/process_incoming_f_ticks_events_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe ProcessIncomingFTicksEvents do

--- a/spec/jobs/receive_events_from_discovery_service_spec.rb
+++ b/spec/jobs/receive_events_from_discovery_service_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe ReceiveEventsFromDiscoveryService, type: :job do
 
         it 'does not write the event to the secondary queue' do
           redis = Redis.new
-          expect { run }.not_to change { redis.llen('wayf_access_record') }
+          expect { run }.not_to(change { redis.llen('wayf_access_record') })
         end
       end
 

--- a/spec/jobs/receive_events_from_discovery_service_spec.rb
+++ b/spec/jobs/receive_events_from_discovery_service_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe ReceiveEventsFromDiscoveryService, type: :job do

--- a/spec/jobs/update_from_federation_registry_spec.rb
+++ b/spec/jobs/update_from_federation_registry_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe UpdateFromFederationRegistry, type: :job do
@@ -53,7 +54,7 @@ RSpec.describe UpdateFromFederationRegistry, type: :job do
   end
 
   let(:default_attr_data) do
-    oid_tail_pattern = Array.new(rand(6)) { %w(# # # ## #####).sample }
+    oid_tail_pattern = Array.new(rand(6)) { %w[# # # ## #####].sample }
                             .join('.')
     {
       id: 1,
@@ -470,7 +471,7 @@ RSpec.describe UpdateFromFederationRegistry, type: :job do
 
       let(:attributes) do
         i = rand(9999)
-        oid_tail_pattern = Array.new(rand(6)) { %w(# # # ## #####).sample }
+        oid_tail_pattern = Array.new(rand(6)) { %w[# # # ## #####].sample }
                                 .join('.')
 
         Array.new(20) do

--- a/spec/jobs/update_from_rapid_connect_spec.rb
+++ b/spec/jobs/update_from_rapid_connect_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe UpdateFromRapidConnect do

--- a/spec/lib/api_constraints_spec.rb
+++ b/spec/lib/api_constraints_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 require 'gumboot/shared_examples/api_constraints'
 

--- a/spec/lib/authentication/subject_receiver_spec.rb
+++ b/spec/lib/authentication/subject_receiver_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Authentication::SubjectReceiver do
@@ -8,7 +9,7 @@ RSpec.describe Authentication::SubjectReceiver do
 
   context '#map_attributes' do
     let(:attrs) do
-      keys = %w(edupersontargetedid auedupersonsharedtoken displayname mail)
+      keys = %w[edupersontargetedid auedupersonsharedtoken displayname mail]
       keys.reduce({}) { |a, e| a.merge(e => e) }
     end
 

--- a/spec/models/activation_spec.rb
+++ b/spec/models/activation_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Activation, type: :model do

--- a/spec/models/api_subject_spec.rb
+++ b/spec/models/api_subject_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 require 'gumboot/shared_examples/api_subjects'
 

--- a/spec/models/automated_report_instance_spec.rb
+++ b/spec/models/automated_report_instance_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe AutomatedReportInstance, type: :model do

--- a/spec/models/automated_report_spec.rb
+++ b/spec/models/automated_report_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe AutomatedReport, type: :model do
@@ -26,11 +27,11 @@ RSpec.describe AutomatedReport, type: :model do
     end
 
     it 'requires no target for targetless reports' do
-      targetless_reports = %w(
+      targetless_reports = %w[
         DailyDemandReport FederatedSessionsReport FederationGrowthReport
         IdentityProviderAttributesReport
         IdentityProviderUtilizationReport ServiceProviderUtilizationReport
-      )
+      ]
       targetless_reports.each do |klass|
         subject.report_class = klass
         expect(subject).to allow_value(nil).for(:target)
@@ -42,8 +43,8 @@ RSpec.describe AutomatedReport, type: :model do
 
     it 'requires an object type identifier for object reports' do
       subject.report_class = 'SubscriberRegistrationsReport'
-      types = %w(identity_providers service_providers organizations
-                 rapid_connect_services services)
+      types = %w[identity_providers service_providers organizations
+                 rapid_connect_services services]
       types.each do |type|
         expect(subject).to allow_value(type).for(:target)
       end
@@ -51,10 +52,10 @@ RSpec.describe AutomatedReport, type: :model do
     end
 
     it 'requires an IdP entity_id for IdP reports' do
-      idp_reports = %w(
+      idp_reports = %w[
         IdentityProviderSessionsReport IdentityProviderDailyDemandReport
         IdentityProviderDestinationServicesReport
-      )
+      ]
 
       idp_reports.each do |klass|
         subject.report_class = klass
@@ -66,10 +67,10 @@ RSpec.describe AutomatedReport, type: :model do
     end
 
     it 'requires an SP entity_id for SP reports' do
-      sp_reports = %w(
+      sp_reports = %w[
         ServiceProviderSessionsReport ServiceProviderDailyDemandReport
         ServiceProviderSourceIdentityProvidersReport ServiceCompatibilityReport
-      )
+      ]
       sp_reports.each do |klass|
         subject.report_class = klass
         expect(subject).to allow_value(sp.entity_id).for(:target)
@@ -80,7 +81,7 @@ RSpec.describe AutomatedReport, type: :model do
     end
 
     it 'requires an attribute name for attribute reports' do
-      %w(ProvidedAttributeReport RequestedAttributeReport).each do |klass|
+      %w[ProvidedAttributeReport RequestedAttributeReport].each do |klass|
         subject.report_class = klass
         expect(subject).to allow_value(attribute.name).for(:target)
         expect(subject).not_to allow_value(idp.entity_id).for(:target)

--- a/spec/models/automated_report_subscription_spec.rb
+++ b/spec/models/automated_report_subscription_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe AutomatedReportSubscription, type: :model do

--- a/spec/models/discovery_service_event_spec.rb
+++ b/spec/models/discovery_service_event_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe DiscoveryServiceEvent, type: :model do

--- a/spec/models/federated_login_event_spec.rb
+++ b/spec/models/federated_login_event_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe FederatedLoginEvent, type: :model do
@@ -59,7 +60,7 @@ RSpec.describe FederatedLoginEvent, type: :model do
         subject.create_instance incoming_event
       end
 
-      %w(#RP #AP #RESULT #TS).each do |field|
+      %w[#RP #AP #RESULT #TS].each do |field|
         it 'should return false when data is invalid' do
           incoming_event.data.remove! field
 

--- a/spec/models/identity_provider_saml_attribute_spec.rb
+++ b/spec/models/identity_provider_saml_attribute_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe IdentityProviderSAMLAttribute, type: :model do

--- a/spec/models/identity_provider_spec.rb
+++ b/spec/models/identity_provider_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe IdentityProvider, type: :model do

--- a/spec/models/incoming_f_ticks_event_spec.rb
+++ b/spec/models/incoming_f_ticks_event_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe IncomingFTicksEvent, type: :model do

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Organization, type: :model do

--- a/spec/models/permission_spec.rb
+++ b/spec/models/permission_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 require 'gumboot/shared_examples/permissions'
 

--- a/spec/models/rapid_connect_service_spec.rb
+++ b/spec/models/rapid_connect_service_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe RapidConnectService, type: :model do

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 require 'gumboot/shared_examples/roles'
 

--- a/spec/models/saml_attribute_spec.rb
+++ b/spec/models/saml_attribute_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe SAMLAttribute, type: :model do

--- a/spec/models/schema_spec.rb
+++ b/spec/models/schema_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 require 'gumboot/shared_examples/database_schema'
 

--- a/spec/models/service_provider_saml_attribute_spec.rb
+++ b/spec/models/service_provider_saml_attribute_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe ServiceProviderSAMLAttribute, type: :model do

--- a/spec/models/service_provider_spec.rb
+++ b/spec/models/service_provider_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe ServiceProvider, type: :model do

--- a/spec/models/subject_spec.rb
+++ b/spec/models/subject_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 require 'gumboot/shared_examples/subjects'
 

--- a/spec/models/subject_spec.rb
+++ b/spec/models/subject_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Subject, type: :model do
         before { object.roles << role }
 
         it 'makes no change' do
-          expect { run }.not_to change { roles }
+          expect { run }.not_to(change { roles })
         end
       end
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -13,7 +13,7 @@ require 'webmock/rspec'
 require 'capybara/rspec'
 require 'capybara/poltergeist'
 
-Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
+Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
 
 ActiveRecord::Migration.maintain_test_schema!
 

--- a/spec/reports/daily_demand_report_spec.rb
+++ b/spec/reports/daily_demand_report_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe DailyDemandReport do

--- a/spec/reports/federated_sessions_report_spec.rb
+++ b/spec/reports/federated_sessions_report_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe FederatedSessionsReport do

--- a/spec/reports/federation_growth_report_spec.rb
+++ b/spec/reports/federation_growth_report_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe FederationGrowthReport do
@@ -46,8 +47,8 @@ RSpec.describe FederationGrowthReport do
     point - (range_count % 2)
   end
 
-  [:organization, :identity_provider,
-   :rapid_connect_service, :service_provider].each do |type|
+  %i[organization identity_provider
+     rapid_connect_service service_provider].each do |type|
     let(type) { create type }
     let("#{type}_02") { create type }
   end
@@ -106,8 +107,8 @@ RSpec.describe FederationGrowthReport do
   context '#generate report' do
     let(:report) { subject.generate }
     it 'output structure should match stacked_report' do
-      [:organizations,
-       :identity_providers, :services].each do |type|
+      %i[organizations
+         identity_providers services].each do |type|
         report[:data][type].each { |i| expect(i.count).to eq(3) }
       end
     end

--- a/spec/reports/identity_provider_attributes_report_spec.rb
+++ b/spec/reports/identity_provider_attributes_report_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe IdentityProviderAttributesReport do

--- a/spec/reports/identity_provider_daily_demand_report_spec.rb
+++ b/spec/reports/identity_provider_daily_demand_report_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe IdentityProviderDailyDemandReport do

--- a/spec/reports/identity_provider_destination_services_report_spec.rb
+++ b/spec/reports/identity_provider_destination_services_report_spec.rb
@@ -13,11 +13,11 @@ RSpec.describe IdentityProviderDestinationServicesReport do
   let(:finish) { Time.zone.now.end_of_day }
 
   let(:idp) { create :identity_provider }
-  let(:idp_02) { create :identity_provider }
-  let(:sp_01) { create :service_provider }
-  let(:sp_02) { create :service_provider }
-  let(:sp_03) { create :service_provider }
-  let(:sp_04) { create :service_provider }
+  let(:idp2) { create :identity_provider }
+  let(:sp1) { create :service_provider }
+  let(:sp2) { create :service_provider }
+  let(:sp3) { create :service_provider }
+  let(:sp4) { create :service_provider }
 
   subject do
     IdentityProviderDestinationServicesReport.new(idp.entity_id, start, finish)
@@ -40,39 +40,34 @@ RSpec.describe IdentityProviderDestinationServicesReport do
 
       create_list :discovery_service_event, 20, :response,
                   selected_idp: idp.entity_id,
-                  initiating_sp: sp_01.entity_id
+                  initiating_sp: sp1.entity_id
 
       create_list :discovery_service_event, 5, :response,
                   selected_idp: idp.entity_id,
-                  initiating_sp: sp_02.entity_id
+                  initiating_sp: sp2.entity_id
 
       create_list :discovery_service_event, 10,
                   selected_idp: idp.entity_id,
-                  initiating_sp: sp_03.entity_id,
+                  initiating_sp: sp3.entity_id,
                   timestamp: 20.days.ago.beginning_of_day
 
       create_list :discovery_service_event, 5, :response,
-                  selected_idp: idp_02.entity_id,
-                  initiating_sp: sp_04.entity_id
+                  selected_idp: idp2.entity_id,
+                  initiating_sp: sp4.entity_id
     end
 
     it 'creates report :rows with number of related SPs and SP names
         only with existing entities' do
-      sp_name_01 = sp_01.name
-      sp_name_02 = sp_02.name
-
-      expect(report[:rows]).to include([sp_name_01, '20'])
-      expect(report[:rows]).to include([sp_name_02, '5'])
+      expect(report[:rows]).to include([sp1.name, '20'])
+      expect(report[:rows]).to include([sp2.name, '5'])
     end
 
     it 'report should not include sessions out of range' do
-      sp_name_03 = sp_03.name
-      expect(report[:rows]).not_to include([sp_name_03, anything])
+      expect(report[:rows]).not_to include([sp3.name, anything])
     end
 
     it 'report should not include sessions from irrelevant entities' do
-      sp_name_04 = sp_04.name
-      expect(report[:rows]).not_to include([sp_name_04, anything])
+      expect(report[:rows]).not_to include([sp4.name, anything])
     end
   end
 end

--- a/spec/reports/identity_provider_destination_services_report_spec.rb
+++ b/spec/reports/identity_provider_destination_services_report_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe IdentityProviderDestinationServicesReport do

--- a/spec/reports/identity_provider_sessions_report_spec.rb
+++ b/spec/reports/identity_provider_sessions_report_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe IdentityProviderSessionsReport do

--- a/spec/reports/identity_provider_utilization_report_spec.rb
+++ b/spec/reports/identity_provider_utilization_report_spec.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe IdentityProviderUtilizationReport do
   let(:type) { 'identity-provider-utilization' }
-  let(:header) { [%w(Name Sessions)] }
+  let(:header) { [%w[Name Sessions]] }
   let(:title) { 'Identity Provider Utilization Report' }
 
   subject { IdentityProviderUtilizationReport.new(start, finish) }

--- a/spec/reports/provided_attribute_report_spec.rb
+++ b/spec/reports/provided_attribute_report_spec.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe ProvidedAttributeReport do
   let(:type) { 'provided-attribute' }
-  let(:header) { [%w(Name Supported)] }
+  let(:header) { [%w[Name Supported]] }
 
   let(:first_attribute) { create :saml_attribute }
   let(:second_attribute) { create :saml_attribute }

--- a/spec/reports/requested_attribute_report_spec.rb
+++ b/spec/reports/requested_attribute_report_spec.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe RequestedAttributeReport do
   let(:type) { 'requested-attribute' }
-  let(:header) { [%w(Name Status)] }
+  let(:header) { [%w[Name Status]] }
 
   let(:required_attribute) { create :saml_attribute }
   let(:optional_attribute) { create :saml_attribute }
@@ -50,7 +51,7 @@ RSpec.describe RequestedAttributeReport do
     end
 
     it 'determines attribute status for each SP' do
-      status_flags = %w(required optional none)
+      status_flags = %w[required optional none]
       status_flags.delete(status)
 
       active_service_providers.map do |k|

--- a/spec/reports/service_compatibility_report_spec.rb
+++ b/spec/reports/service_compatibility_report_spec.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe ServiceCompatibilityReport do
   let(:type) { 'service-compatibility' }
-  let(:header) { [%w(Name Required Optional Compatible)] }
+  let(:header) { [%w[Name Required Optional Compatible]] }
 
   let(:service_provider_01) { create :service_provider }
   let(:core_attributes) { create_list :saml_attribute, 8, :core_attribute }

--- a/spec/reports/service_provider_daily_demand_report_spec.rb
+++ b/spec/reports/service_provider_daily_demand_report_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe ServiceProviderDailyDemandReport do

--- a/spec/reports/service_provider_sessions_report_spec.rb
+++ b/spec/reports/service_provider_sessions_report_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe ServiceProviderSessionsReport do

--- a/spec/reports/service_provider_source_identity_providers_report_spec.rb
+++ b/spec/reports/service_provider_source_identity_providers_report_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe ServiceProviderSourceIdentityProvidersReport do

--- a/spec/reports/service_provider_source_identity_providers_report_spec.rb
+++ b/spec/reports/service_provider_source_identity_providers_report_spec.rb
@@ -13,11 +13,11 @@ RSpec.describe ServiceProviderSourceIdentityProvidersReport do
   let(:finish) { Time.zone.now.end_of_day }
 
   let(:sp) { create :service_provider }
-  let(:sp_02) { create :service_provider }
-  let(:idp_01) { create :identity_provider }
-  let(:idp_02) { create :identity_provider }
-  let(:idp_03) { create :identity_provider }
-  let(:idp_04) { create :identity_provider }
+  let(:sp2) { create :service_provider }
+  let(:idp1) { create :identity_provider }
+  let(:idp2) { create :identity_provider }
+  let(:idp3) { create :identity_provider }
+  let(:idp4) { create :identity_provider }
 
   subject do
     ServiceProviderSourceIdentityProvidersReport
@@ -41,39 +41,34 @@ RSpec.describe ServiceProviderSourceIdentityProvidersReport do
 
       create_list :discovery_service_event, 20, :response,
                   initiating_sp: sp.entity_id,
-                  selected_idp: idp_01.entity_id
+                  selected_idp: idp1.entity_id
 
       create_list :discovery_service_event, 5, :response,
                   initiating_sp: sp.entity_id,
-                  selected_idp: idp_02.entity_id
+                  selected_idp: idp2.entity_id
 
       create_list :discovery_service_event, 10,
                   initiating_sp: sp.entity_id,
-                  selected_idp: idp_03.entity_id,
+                  selected_idp: idp3.entity_id,
                   timestamp: 20.days.ago.beginning_of_day
 
       create_list :discovery_service_event, 5, :response,
-                  initiating_sp: sp_02.entity_id,
-                  selected_idp: idp_04.entity_id
+                  initiating_sp: sp2.entity_id,
+                  selected_idp: idp4.entity_id
     end
 
     it 'creates report :rows with number of related IdPs and IdP names
         only with existing entities' do
-      idp_name_01 = idp_01.name
-      idp_name_02 = idp_02.name
-
-      expect(report[:rows]).to include([idp_name_01, '20'])
-      expect(report[:rows]).to include([idp_name_02, '5'])
+      expect(report[:rows]).to include([idp1.name, '20'])
+      expect(report[:rows]).to include([idp2.name, '5'])
     end
 
     it 'report should not include sessions out of range' do
-      idp_name_03 = idp_03.name
-      expect(report[:rows]).not_to include([idp_name_03, anything])
+      expect(report[:rows]).not_to include([idp3.name, anything])
     end
 
     it 'report should not include sessions from irrelevant entities' do
-      idp_name_04 = idp_04.name
-      expect(report[:rows]).not_to include([idp_name_04, anything])
+      expect(report[:rows]).not_to include([idp4.name, anything])
     end
   end
 end

--- a/spec/reports/service_provider_utilization_report_spec.rb
+++ b/spec/reports/service_provider_utilization_report_spec.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe ServiceProviderUtilizationReport do
   let(:type) { 'service-provider-utilization' }
-  let(:header) { [%w(Name Sessions)] }
+  let(:header) { [%w[Name Sessions]] }
   let(:title) { 'Service Provider Utilization Report' }
 
   subject { ServiceProviderUtilizationReport.new(start, finish) }

--- a/spec/reports/subscriber_registrations_report_spec.rb
+++ b/spec/reports/subscriber_registrations_report_spec.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe SubscriberRegistrationsReport do
-  let(:header) { [%w(Name Registration\ Date)] }
+  let(:header) { [%w[Name Registration\ Date]] }
   let(:type) { 'subscriber-registrations' }
 
   let(:organization) { create(:organization) }

--- a/spec/reports/tabular_report/lint_spec.rb
+++ b/spec/reports/tabular_report/lint_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe TabularReport::Lint do
@@ -26,7 +27,7 @@ RSpec.describe TabularReport::Lint do
       title: 'A tabular report!',
       header: [['Column 1', 'Column 2', 'Column 3']],
       footer: [['Footer 1', 'Footer 2', 'Footer 3']],
-      rows: [%w(a b c), %w(d e f), %w(g h i), %w(j k l)]
+      rows: [%w[a b c], %w[d e f], %w[g h i], %w[j k l]]
     }
   end
 
@@ -60,12 +61,12 @@ RSpec.describe TabularReport::Lint do
   end
 
   context 'when the header is an array of strings' do
-    let(:output) { valid_output.merge(header: %w(a b c)) }
+    let(:output) { valid_output.merge(header: %w[a b c]) }
     fails_with 'header must be an array of arrays'
   end
 
   context 'when the header has too few items' do
-    let(:output) { valid_output.merge(header: [%w(a b)]) }
+    let(:output) { valid_output.merge(header: [%w[a b]]) }
     fails_with 'row data has inconsistent width'
   end
 
@@ -87,7 +88,7 @@ RSpec.describe TabularReport::Lint do
   end
 
   context 'when the footer is an array of strings' do
-    let(:output) { valid_output.merge(footer: %w(a b c)) }
+    let(:output) { valid_output.merge(footer: %w[a b c]) }
     fails_with 'footer must be an array of arrays'
   end
 
@@ -97,7 +98,7 @@ RSpec.describe TabularReport::Lint do
   end
 
   context 'when the footer has too few items' do
-    let(:output) { valid_output.merge(footer: [%w(a b)]) }
+    let(:output) { valid_output.merge(footer: [%w[a b]]) }
     fails_with 'footer size is incorrect'
   end
 
@@ -114,7 +115,7 @@ RSpec.describe TabularReport::Lint do
   end
 
   context 'when the row data is an array of strings' do
-    let(:output) { valid_output.merge(rows: %w(a b c d e f g)) }
+    let(:output) { valid_output.merge(rows: %w[a b c d e f g]) }
     fails_with 'row data must be an array of arrays'
   end
 
@@ -124,7 +125,7 @@ RSpec.describe TabularReport::Lint do
   end
 
   context 'when the rows differ in length' do
-    let(:output) { valid_output.merge(rows: [%w(a b c), %w(d e)]) }
+    let(:output) { valid_output.merge(rows: [%w[a b c], %w[d e]]) }
     fails_with 'row data has inconsistent width'
   end
 end

--- a/spec/reports/tabular_report_spec.rb
+++ b/spec/reports/tabular_report_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe TabularReport do

--- a/spec/reports/time_series_report/lint_spec.rb
+++ b/spec/reports/time_series_report/lint_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe TimeSeriesReport::Lint do
@@ -29,7 +30,7 @@ RSpec.describe TimeSeriesReport::Lint do
         series_b: 'the B series',
         series_c: 'the C series'
       },
-      series: %w(series_a series_b series_c),
+      series: %w[series_a series_b series_c],
       units: 'Hz',
       title: 'A graph!',
       range: {
@@ -127,7 +128,7 @@ RSpec.describe TimeSeriesReport::Lint do
 
   context 'when a series is named "y"' do
     let(:output) do
-      valid_output.merge(series: valid_output[:series] + %w(y))
+      valid_output.merge(series: valid_output[:series] + %w[y])
     end
 
     fails_with 'series name "y" is not permitted'

--- a/spec/reports/time_series_report_spec.rb
+++ b/spec/reports/time_series_report_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe TimeSeriesReport do

--- a/spec/routing/administrator_reports_routing_spec.rb
+++ b/spec/routing/administrator_reports_routing_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe AdministratorReportsController, type: :routing do

--- a/spec/routing/automated_report_instances_controller_routing_spec.rb
+++ b/spec/routing/automated_report_instances_controller_routing_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe AutomatedReportInstancesController, type: :routing do

--- a/spec/routing/automated_reports_routing_spec.rb
+++ b/spec/routing/automated_reports_routing_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe AutomatedReportsController, type: :routing do

--- a/spec/routing/compliance_reports_routing_spec.rb
+++ b/spec/routing/compliance_reports_routing_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe ComplianceReportsController, type: :routing do

--- a/spec/routing/federation_reports_routing_spec.rb
+++ b/spec/routing/federation_reports_routing_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe FederationReportsController, type: :routing do

--- a/spec/routing/identity_provider_reports_routing_spec.rb
+++ b/spec/routing/identity_provider_reports_routing_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe IdentityProviderReportsController, type: :routing do

--- a/spec/routing/service_provider_reports_routing_spec.rb
+++ b/spec/routing/service_provider_reports_routing_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe ServiceProviderReportsController, type: :routing do

--- a/spec/routing/subscriber_reports_dashboard_routing_spec.rb
+++ b/spec/routing/subscriber_reports_dashboard_routing_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe SubscriberReportsDashboardController, type: :routing do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'simplecov'
 require 'fakeredis'
 

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 RSpec.configure do |config|
   config.before(:suite) do
     DatabaseCleaner.clean_with(:truncation)

--- a/spec/support/federation_object.rb
+++ b/spec/support/federation_object.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 RSpec.shared_examples 'a federation object' do
   context '#active' do
     let(:object) do

--- a/spec/support/field_validations.rb
+++ b/spec/support/field_validations.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 RSpec.shared_examples 'a field accepting the urlsafe base64 alphabet' do
   it { is_expected.to allow_value(SecureRandom.urlsafe_base64).for(field) }
   it { is_expected.not_to allow_value('abcdefg%').for(field) }

--- a/spec/support/scaling_steps.rb
+++ b/spec/support/scaling_steps.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 RSpec.shared_examples 'report with scalable steps' do
   around { |spec| Timecop.freeze { spec.run } }
 

--- a/spec/support/subscriber_reports_controller.rb
+++ b/spec/support/subscriber_reports_controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 RSpec.shared_examples 'a Subscriber Report' do
   let(:organization) { create :organization }
 

--- a/spec/support/subscription_features.rb
+++ b/spec/support/subscription_features.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
+
 RSpec.shared_examples 'Subscribing to an automated report with target' do
-  %w(monthly quarterly yearly).each do |interval|
+  %w[monthly quarterly yearly].each do |interval|
     given!("auto_report_#{interval}".to_sym) do
       create :automated_report,
              interval: interval,
@@ -31,7 +32,7 @@ RSpec.shared_examples 'Subscribing to an automated report with target' do
       click_link(button)
       expect(current_path).to eq("/#{controller}/#{path}")
 
-      %w(Monthly Quarterly Yearly).each do |interval|
+      %w[Monthly Quarterly Yearly].each do |interval|
         select(object.name, from: list)
         click_button('Generate')
         click_button('Subscribe')
@@ -50,7 +51,7 @@ RSpec.shared_examples 'Subscribing to an automated report with target' do
       click_link(button)
       expect(current_path).to eq("/#{controller}/#{path}")
 
-      %w(Monthly Quarterly Yearly).each do |interval|
+      %w[Monthly Quarterly Yearly].each do |interval|
         select(object.name, from: list)
         click_button('Generate')
         click_button('Subscribe')

--- a/spec/support/subscription_with_nil_target_features.rb
+++ b/spec/support/subscription_with_nil_target_features.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
+
 RSpec.shared_examples 'Subscribing to a nil class report' do
-  %w(monthly quarterly yearly).each do |interval|
+  %w[monthly quarterly yearly].each do |interval|
     given!("auto_report_#{interval}".to_sym) do
       create :automated_report,
              interval: interval,
@@ -31,7 +32,7 @@ RSpec.shared_examples 'Subscribing to a nil class report' do
       expect(current_path).to eq("/#{controller}/#{path}")
       expect(page).to have_css(template)
 
-      %w(Monthly Quarterly Yearly).each do |interval|
+      %w[Monthly Quarterly Yearly].each do |interval|
         click_button('Subscribe')
         click_link(interval)
         expect(current_path).to eq("/#{controller}/#{path}")
@@ -48,7 +49,7 @@ RSpec.shared_examples 'Subscribing to a nil class report' do
       expect(current_path).to eq("/#{controller}/#{path}")
       expect(page).to have_css(template)
 
-      %w(Monthly Quarterly Yearly).each do |interval|
+      %w[Monthly Quarterly Yearly].each do |interval|
         click_button('Subscribe')
         click_link(interval)
         expect(current_path).to eq("/#{controller}/#{path}")

--- a/spec/support/utilization_reports.rb
+++ b/spec/support/utilization_reports.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
+
 RSpec.shared_context 'Utilization Report' do
   around { |spec| Timecop.freeze { spec.run } }
 
   let!(:start) { 10.days.ago.beginning_of_day }
   let!(:finish) { 1.day.ago.beginning_of_day }
-  let(:header) { [%w(Name Sessions)] }
+  let(:header) { [%w[Name Sessions]] }
 
   let(:included_objects) { create_list(object_type, rand(4..7)) }
   let(:before_objects) { create_list(object_type, rand(1..3)) }
@@ -63,7 +64,7 @@ RSpec.shared_context 'Utilization Report' do
     context 'with random case permutations' do
       before do
         objects.each do |o|
-          o.update!(name: o.name.send([:upcase, :downcase].sample))
+          o.update!(name: o.name.send(%i[upcase downcase].sample))
         end
       end
 


### PR DESCRIPTION
Part 1 of the "update dependencies" saga for reporting service.

Part 2 is going to be a bit more involved, but Gumboot's `ApplicationController` tests can't be run against Rails 4.x anymore so I had to disable those and the coverage requirement to submit this PR.