### PR TITLE
Fix time bug for the shorter February month

### DIFF
--- a/app/controllers/administrator_reports_controller.rb
+++ b/app/controllers/administrator_reports_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class AdministratorReportsController < ApplicationController
+  include Steps
+
   before_action { check_access! 'admin:report' }
   before_action :set_range_params,
                 except: %i[subscriber_registrations_report index]
@@ -48,32 +50,5 @@ class AdministratorReportsController < ApplicationController
 
     report = ServiceProviderUtilizationReport.new(start, finish)
     @data = JSON.generate(report.generate)
-  end
-
-  private
-
-  def set_range_params
-    @start = params[:start]
-    @end = params[:end]
-  end
-
-  def start
-    return nil if params[:start].blank?
-    Time.zone.parse(params[:start]).beginning_of_day
-  end
-
-  def finish
-    return nil if params[:end].blank?
-    Time.zone.parse(params[:end]).tomorrow.beginning_of_day
-  end
-
-  def scaled_steps
-    range = finish - start
-
-    return 24 if range >= 1.year
-    return 12 if range >= 6.months
-    return 6 if range >= 3.months
-    return 2 if range >= 1.month
-    1
   end
 end

--- a/app/controllers/subscriber_reports.rb
+++ b/app/controllers/subscriber_reports.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class SubscriberReports < ApplicationController
+  include Steps
+
   before_action { permitted_objects(model_object) }
   before_action :requested_entity
   before_action :set_range_params
@@ -43,30 +45,5 @@ class SubscriberReports < ApplicationController
     @entities = active_objects.select do |sp|
       subject.permits? permission_string(sp)
     end
-  end
-
-  def set_range_params
-    @start = params[:start]
-    @end = params[:end]
-  end
-
-  def start
-    return nil if params[:start].blank?
-    Time.zone.parse(params[:start]).beginning_of_day
-  end
-
-  def finish
-    return nil if params[:end].blank?
-    Time.zone.parse(params[:end]).tomorrow.beginning_of_day
-  end
-
-  def scaled_steps
-    range = finish - start
-
-    return 24 if range >= 1.year
-    return 12 if range >= 6.months
-    return 6 if range >= 3.months
-    return 2 if range >= 1.month
-    1
   end
 end

--- a/lib/steps.rb
+++ b/lib/steps.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+module Steps
+  def set_range_params
+    @start = params[:start]
+    @end = params[:end]
+  end
+
+  def start
+    return nil if params[:start].blank?
+    Time.zone.parse(params[:start]).beginning_of_day
+  end
+
+  def finish
+    return nil if params[:end].blank?
+    Time.zone.parse(params[:end]).tomorrow.beginning_of_day
+  end
+
+  def scaled_steps
+    range = range(start, finish)
+
+    return 24 if range >= 1.year
+    return 12 if range >= 6.months
+    return 6 if range >= 3.months
+    return 2 if range >= 1.month
+    1
+  end
+
+  def range(start, finish)
+    range = finish - start
+
+    # February could have less days, therefore offset
+    range += 2.days if (start.month..finish.month).cover?(2)
+
+    range
+  end
+end

--- a/lib/steps.rb
+++ b/lib/steps.rb
@@ -17,21 +17,13 @@ module Steps
   end
 
   def scaled_steps
-    range = range(start, finish)
+    s = start
+    f = finish
 
-    return 24 if range >= 1.year
-    return 12 if range >= 6.months
-    return 6 if range >= 3.months
-    return 2 if range >= 1.month
+    return 24 if f >= 1.year.since(s)
+    return 12 if f >= 6.months.since(s)
+    return 6 if f >= 3.months.since(s)
+    return 2 if f >= 1.month.since(s)
     1
-  end
-
-  def range(start, finish)
-    range = finish - start
-
-    # February could have less days, therefore offset
-    range += 2.days if (start.month..finish.month).cover?(2)
-
-    range
   end
 end

--- a/lib/steps.rb
+++ b/lib/steps.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Steps
   def set_range_params
     @start = params[:start]

--- a/spec/support/scaling_steps.rb
+++ b/spec/support/scaling_steps.rb
@@ -15,6 +15,20 @@ RSpec.shared_examples 'report with scalable steps' do
     { start: Time.now.utc - 1.month, end: Time.now.utc }
   end
 
+  let(:range_1_month_february_exception) do
+    {
+      start: DateTime.parse('2017-02-09 00:00:00').utc,
+      end: DateTime.parse('2017-03-09 00:00:00').utc
+    }
+  end
+
+  let(:range_2_months_february_exception) do
+    {
+      start: DateTime.parse('2017-01-09 00:00:00').utc,
+      end: DateTime.parse('2017-03-09 00:00:00').utc
+    }
+  end
+
   let(:range_2_months) do
     { start: Time.now.utc - 2.months, end: Time.now.utc }
   end
@@ -63,15 +77,32 @@ RSpec.shared_examples 'report with scalable steps' do
     end
   end
 
-  it 'Steps should be 2 hours within 1 to 3 months' do
-    [range_1_month, range_2_months].each do |rng|
-      post path, params: params.merge(rng)
+  context 'Steps should be 2 hours within 1 to 3 months' do
+    it 'normal' do
+      [range_1_month, range_2_months].each do |rng|
+        post path, params: params.merge(rng)
 
-      data = JSON.parse(assigns[:data], symbolize_names: true)
-      sessions = data[:data][:sessions]
+        data = JSON.parse(assigns[:data], symbolize_names: true)
+        sessions = data[:data][:sessions]
 
-      expect(sessions[1]).to eq([7200, 0.0])
-      expect(sessions[2]).to eq([7200 * 2, 0.0])
+        expect(sessions[1]).to eq([7200, 0.0])
+        expect(sessions[2]).to eq([7200 * 2, 0.0])
+      end
+    end
+
+    it 'February exception' do
+      [
+        range_1_month_february_exception,
+        range_2_months_february_exception
+      ].each do |rng|
+        post path, params.merge(rng)
+
+        data = JSON.parse(assigns[:data], symbolize_names: true)
+        sessions = data[:data][:sessions]
+
+        expect(sessions[1]).to eq([7200, 0.0])
+        expect(sessions[2]).to eq([7200 * 2, 0.0])
+      end
     end
   end
 

--- a/spec/support/scaling_steps.rb
+++ b/spec/support/scaling_steps.rb
@@ -29,6 +29,20 @@ RSpec.shared_examples 'report with scalable steps' do
     }
   end
 
+  let(:range_3_months_february_exception) do
+    {
+      start: DateTime.parse('2017-01-09 00:00:00').utc,
+      end: DateTime.parse('2017-04-09 00:00:00').utc
+    }
+  end
+
+  let(:range_3_months_across_year_end_february_exception) do
+    {
+      start: DateTime.parse('2016-12-09 00:00:00').utc,
+      end: DateTime.parse('2017-03-09 00:00:00').utc
+    }
+  end
+
   let(:range_2_months) do
     { start: Time.now.utc - 2.months, end: Time.now.utc }
   end
@@ -78,7 +92,7 @@ RSpec.shared_examples 'report with scalable steps' do
   end
 
   context 'Steps should be 2 hours within 1 to 3 months' do
-    it 'normal' do
+    it 'behaves correctly for 30+ day months' do
       [range_1_month, range_2_months].each do |rng|
         post path, params: params.merge(rng)
 
@@ -90,7 +104,7 @@ RSpec.shared_examples 'report with scalable steps' do
       end
     end
 
-    it 'February exception' do
+    it 'behaves correctly when the time range spans February' do
       [
         range_1_month_february_exception,
         range_2_months_february_exception
@@ -106,15 +120,32 @@ RSpec.shared_examples 'report with scalable steps' do
     end
   end
 
-  it 'Steps should be 6 hours within 3 to 6 months' do
-    [range_3_months, range_4_months].each do |rng|
-      post path, params: params.merge(rng)
+  context 'Steps should be 6 hours within 3 to 6 months' do
+    it 'behaves correctly for 30+ day months' do
+      [range_3_months, range_4_months].each do |rng|
+        post path, params: params.merge(rng)
 
-      data = JSON.parse(assigns[:data], symbolize_names: true)
-      sessions = data[:data][:sessions]
+        data = JSON.parse(assigns[:data], symbolize_names: true)
+        sessions = data[:data][:sessions]
 
-      expect(sessions[1]).to eq([21_600, 0.0])
-      expect(sessions[2]).to eq([21_600 * 2, 0.0])
+        expect(sessions[1]).to eq([21_600, 0.0])
+        expect(sessions[2]).to eq([21_600 * 2, 0.0])
+      end
+    end
+
+    it 'behaves correctly when the time range spans February' do
+      [
+        range_3_months_february_exception,
+        range_3_months_across_year_end_february_exception
+      ].each do |rng|
+        post path, params: params.merge(rng)
+
+        data = JSON.parse(assigns[:data], symbolize_names: true)
+        sessions = data[:data][:sessions]
+
+        expect(sessions[1]).to eq([21_600, 0.0])
+        expect(sessions[2]).to eq([21_600 * 2, 0.0])
+      end
     end
   end
 

--- a/spec/support/scaling_steps.rb
+++ b/spec/support/scaling_steps.rb
@@ -95,7 +95,7 @@ RSpec.shared_examples 'report with scalable steps' do
         range_1_month_february_exception,
         range_2_months_february_exception
       ].each do |rng|
-        post path, params.merge(rng)
+        post path, params: params.merge(rng)
 
         data = JSON.parse(assigns[:data], symbolize_names: true)
         sessions = data[:data][:sessions]


### PR DESCRIPTION
Ruby's subtraction of dates took into account the shorter February
month.  When you compare this result with `1.month` (ie. 30 days in
Rubyland) you get an incorrect comparison and a failing test.

This creates a small exception for February, removes duplicate code and
adds a February specific test in.