### PR TITLE
Feature sessions source

### DIFF
--- a/app/controllers/administrator_reports_controller.rb
+++ b/app/controllers/administrator_reports_controller.rb
@@ -28,28 +28,28 @@ class AdministratorReportsController < ApplicationController
   def daily_demand_report
     return if params[:start].blank? || params[:end].blank?
 
-    report = DailyDemandReport.new(start, finish)
+    report = DailyDemandReport.new(start, finish, @source)
     @data = JSON.generate(report.generate)
   end
 
   def federated_sessions_report
     return if params[:start].blank? || params[:end].blank?
 
-    report = FederatedSessionsReport.new(start, finish, scaled_steps)
+    report = FederatedSessionsReport.new(start, finish, scaled_steps, @source)
     @data = JSON.generate(report.generate)
   end
 
   def identity_provider_utilization_report
     return if params[:start].blank? || params[:end].blank?
 
-    report = IdentityProviderUtilizationReport.new(start, finish)
+    report = IdentityProviderUtilizationReport.new(start, finish, @source)
     @data = JSON.generate(report.generate)
   end
 
   def service_provider_utilization_report
     return if params[:start].blank? || params[:end].blank?
 
-    report = ServiceProviderUtilizationReport.new(start, finish)
+    report = ServiceProviderUtilizationReport.new(start, finish, @source)
     @data = JSON.generate(report.generate)
   end
 

--- a/app/controllers/administrator_reports_controller.rb
+++ b/app/controllers/administrator_reports_controller.rb
@@ -4,6 +4,9 @@ class AdministratorReportsController < ApplicationController
   before_action { check_access! 'admin:report' }
   before_action :set_range_params,
                 except: %i[subscriber_registrations_report index]
+  before_action :set_source,
+                except: %i[subscriber_registrations_report
+                           federation_growth_report index]
 
   def index; end
 
@@ -55,6 +58,11 @@ class AdministratorReportsController < ApplicationController
   def set_range_params
     @start = params[:start]
     @end = params[:end]
+  end
+
+  def set_source
+    return nil if params[:source].blank?
+    @source = params[:source]
   end
 
   def start

--- a/app/controllers/automated_reports_controller.rb
+++ b/app/controllers/automated_reports_controller.rb
@@ -52,6 +52,13 @@ class AutomatedReportsController < AutomatedReports
   end
 
   def automated_report_params
+    params.require(%i[report_class interval])
+    params.require(:source) if AutomatedReport.report_class_needs_source?(
+      params[:report_class]
+    )
+    params.require(:target) if AutomatedReport.report_class_needs_target?(
+      params[:report_class]
+    )
     params.permit(:interval, :target, :report_class, :source)
   end
 end

--- a/app/controllers/automated_reports_controller.rb
+++ b/app/controllers/automated_reports_controller.rb
@@ -52,6 +52,6 @@ class AutomatedReportsController < AutomatedReports
   end
 
   def automated_report_params
-    params.permit(:interval, :target, :report_class)
+    params.permit(:interval, :target, :report_class, :source)
   end
 end

--- a/app/controllers/federation_reports_controller.rb
+++ b/app/controllers/federation_reports_controller.rb
@@ -40,8 +40,10 @@ class FederationReportsController < ApplicationController
 
   def set_source
     @source = params[:source]
-    # TODO: set default source for daily_remand_report
-    # and federated_sessions_report in application config
-    @source = 'DS' if params[:source].blank?
+    return @source if @source.present?
+    @source = Rails.application.config.reporting_service.default_session_source
+    # Complete fall back: default to DS if source is not set in params
+    # and not in app_config.
+    @source = 'DS' if @source.blank?
   end
 end

--- a/app/controllers/federation_reports_controller.rb
+++ b/app/controllers/federation_reports_controller.rb
@@ -2,7 +2,8 @@
 
 class FederationReportsController < ApplicationController
   before_action :set_range
-  before_action :set_source
+  before_action :set_source, only: %i[federated_sessions_report
+                                      daily_demand_report]
 
   def federation_growth_report
     public_action
@@ -41,6 +42,9 @@ class FederationReportsController < ApplicationController
   def set_source
     @source = params[:source]
     return @source if @source.present?
+    # Have to provide a default for public reports
+    # (DailyDemand and FederatedSessionsReport)
+    # which do not have a form to set the source
     @source = Rails.application.config.reporting_service.default_session_source
     # Complete fall back: default to DS if source is not set in params
     # and not in app_config.

--- a/app/controllers/federation_reports_controller.rb
+++ b/app/controllers/federation_reports_controller.rb
@@ -17,7 +17,7 @@ class FederationReportsController < ApplicationController
     public_action
 
     @data = Rails.cache.fetch('public/federated-sessions') do
-      report = FederatedSessionsReport.new(@start, @end, 10)
+      report = FederatedSessionsReport.new(@start, @end, 10, @source)
       JSON.generate(report.generate)
     end
   end
@@ -26,7 +26,7 @@ class FederationReportsController < ApplicationController
     public_action
 
     @data = Rails.cache.fetch('public/daily-demand') do
-      report = DailyDemandReport.new(@start, @end)
+      report = DailyDemandReport.new(@start, @end, @source)
       JSON.generate(report.generate)
     end
   end

--- a/app/controllers/federation_reports_controller.rb
+++ b/app/controllers/federation_reports_controller.rb
@@ -2,6 +2,7 @@
 
 class FederationReportsController < ApplicationController
   before_action :set_range
+  before_action :set_source
 
   def federation_growth_report
     public_action
@@ -35,5 +36,12 @@ class FederationReportsController < ApplicationController
   def set_range
     @start = 1.year.ago.beginning_of_day
     @end = Time.zone.tomorrow.beginning_of_day
+  end
+
+  def set_source
+    @source = params[:source]
+    # TODO: set default source for daily_remand_report
+    # and federated_sessions_report in application config
+    @source = 'DS' if params[:source].blank?
   end
 end

--- a/app/controllers/subscriber_reports.rb
+++ b/app/controllers/subscriber_reports.rb
@@ -4,6 +4,7 @@ class SubscriberReports < ApplicationController
   before_action { permitted_objects(model_object) }
   before_action :requested_entity
   before_action :set_range_params
+  before_action :set_source
   before_action :access_method
 
   private
@@ -48,6 +49,11 @@ class SubscriberReports < ApplicationController
   def set_range_params
     @start = params[:start]
     @end = params[:end]
+  end
+
+  def set_source
+    return nil if params[:source].blank?
+    @source = params[:source]
   end
 
   def start

--- a/app/controllers/subscriber_reports.rb
+++ b/app/controllers/subscriber_reports.rb
@@ -25,8 +25,8 @@ class SubscriberReports < ApplicationController
   def generate_report(report_type, steps = nil)
     @entity_id = params[:entity_id]
 
-    return report_type.new(@entity_id, start, finish, steps) if steps
-    report_type.new(@entity_id, start, finish)
+    return report_type.new(@entity_id, start, finish, steps, @source) if steps
+    report_type.new(@entity_id, start, finish, @source)
   end
 
   def access_method

--- a/app/controllers/subscriber_reports.rb
+++ b/app/controllers/subscriber_reports.rb
@@ -52,5 +52,4 @@ class SubscriberReports < ApplicationController
     return nil if params[:source].blank?
     @source = params[:source]
   end
-
 end

--- a/app/models/automated_report.rb
+++ b/app/models/automated_report.rb
@@ -36,6 +36,12 @@ class AutomatedReport < ActiveRecord::Base
     REPORTS_THAT_NEED_SOURCE.include?(report_class)
   end
 
+  def source_if_needed
+    return nil unless needs_source?
+    # TODO: default to a value from app_config
+    'DS' if source.blank?
+    source
+  end
 
   private
 

--- a/app/models/automated_report.rb
+++ b/app/models/automated_report.rb
@@ -39,8 +39,12 @@ class AutomatedReport < ActiveRecord::Base
   def source_if_needed
     return nil unless needs_source?
     # TODO: default to a value from app_config
-    'DS' if source.blank?
-    source
+    return source if source.present?
+    return Rails.application.config.reporting_service.default_session_source if
+      Rails.application.config.reporting_service.default_session_source.present?
+    # Complete fall back: default to DS if source is not set in params
+    # and not in app_config.
+    'DS'
   end
 
   private

--- a/app/models/automated_report.rb
+++ b/app/models/automated_report.rb
@@ -32,13 +32,20 @@ class AutomatedReport < ActiveRecord::Base
     klass.find_by_identifying_attribute(target)
   end
 
-  def needs_source?
+  def self.report_class_needs_source?(report_class)
     REPORTS_THAT_NEED_SOURCE.include?(report_class)
+  end
+
+  def self.report_class_needs_target?(report_class)
+    !TARGET_CLASSES[report_class].nil?
+  end
+
+  def needs_source?
+    AutomatedReport.report_class_needs_source?(report_class)
   end
 
   def source_if_needed
     return nil unless needs_source?
-    # TODO: default to a value from app_config
     return source if source.present?
     return Rails.application.config.reporting_service.default_session_source if
       Rails.application.config.reporting_service.default_session_source.present?
@@ -101,7 +108,7 @@ class AutomatedReport < ActiveRecord::Base
   def source_must_be_known_if_needed_by_report_class
     return if report_class.nil?
     return if SOURCE_VALUES.include?(source)
-    return unless REPORTS_THAT_NEED_SOURCE.include?(report_class)
+    return unless needs_source?
     errors.add(:source, 'must be present for ' + report_class)
   end
 

--- a/app/models/automated_report.rb
+++ b/app/models/automated_report.rb
@@ -10,7 +10,7 @@ class AutomatedReport < ActiveRecord::Base
 
   validate :target_must_be_valid_for_report_type,
            :report_class_must_be_known,
-           :source_must_be_known_if_needed_by_report_class
+           :source_must_be_valid_for_report_type
 
   def interval
     value = super
@@ -105,11 +105,11 @@ class AutomatedReport < ActiveRecord::Base
     IdentityProviderUtilizationReport ServiceProviderUtilizationReport
   ].freeze
 
-  def source_must_be_known_if_needed_by_report_class
+  def source_must_be_valid_for_report_type
     return if report_class.nil?
-    return if SOURCE_VALUES.include?(source)
-    return unless needs_source?
-    errors.add(:source, 'must be present for ' + report_class)
+    return if needs_source? && SOURCE_VALUES.include?(source)
+    return if !needs_source? && source.nil?
+    errors.add(:source, 'is not valid for report ' + report_class)
   end
 
   def target_must_be_nil

--- a/app/models/automated_report_instance.rb
+++ b/app/models/automated_report_instance.rb
@@ -70,17 +70,5 @@ class AutomatedReportInstance < ActiveRecord::Base
     REPORTS_THAT_NEED_STEP_WIDTH.include?(automated_report.report_class)
   end
 
-  REPORTS_THAT_NEED_SOURCE = %w[
-    DailyDemandReport FederatedSessionsReport IdentityProviderDailyDemandReport
-    IdentityProviderDestinationServicesReport IdentityProviderSessionsReport
-    ServiceProviderDailyDemandReport ServiceProviderSessionsReport
-    ServiceProviderSourceIdentityProvidersReport
-    IdentityProviderUtilizationReport ServiceProviderUtilizationReport
-  ].freeze
-
-  def needs_source?
-    REPORTS_THAT_NEED_SOURCE.include?(automated_report.report_class)
-  end
-
   private_constant :REPORTS_THAT_NEED_RANGE, :REPORTS_THAT_NEED_STEP_WIDTH
 end

--- a/app/models/automated_report_instance.rb
+++ b/app/models/automated_report_instance.rb
@@ -11,7 +11,7 @@ class AutomatedReportInstance < ActiveRecord::Base
   delegate :interval, to: :automated_report
 
   def materialize
-    args = [automated_report.target, *report_range, step_width].compact
+    args = [automated_report.target, *report_range, step_width, source].compact
     automated_report.report_class.constantize.new(*args)
   end
 
@@ -41,6 +41,13 @@ class AutomatedReportInstance < ActiveRecord::Base
     1
   end
 
+  def source
+    return nil unless needs_source?
+
+    # TODO: this should be specified for the automated report somewhere
+    'DS'
+  end
+
   REPORTS_THAT_NEED_RANGE = %w[
     FederationGrowthReport DailyDemandReport FederatedSessionsReport
     IdentityProviderDailyDemandReport IdentityProviderDestinationServicesReport
@@ -61,6 +68,18 @@ class AutomatedReportInstance < ActiveRecord::Base
 
   def needs_step_width?
     REPORTS_THAT_NEED_STEP_WIDTH.include?(automated_report.report_class)
+  end
+
+  REPORTS_THAT_NEED_SOURCE = %w[
+    DailyDemandReport FederatedSessionsReport IdentityProviderDailyDemandReport
+    IdentityProviderDestinationServicesReport IdentityProviderSessionsReport
+    ServiceProviderDailyDemandReport ServiceProviderSessionsReport
+    ServiceProviderSourceIdentityProvidersReport
+    IdentityProviderUtilizationReport ServiceProviderUtilizationReport
+  ].freeze
+
+  def needs_source?
+    REPORTS_THAT_NEED_SOURCE.include?(automated_report.report_class)
   end
 
   private_constant :REPORTS_THAT_NEED_RANGE, :REPORTS_THAT_NEED_STEP_WIDTH

--- a/app/models/automated_report_instance.rb
+++ b/app/models/automated_report_instance.rb
@@ -11,7 +11,8 @@ class AutomatedReportInstance < ActiveRecord::Base
   delegate :interval, to: :automated_report
 
   def materialize
-    args = [automated_report.target, *report_range, step_width, source].compact
+    args = [automated_report.target, *report_range, step_width,
+            automated_report.source_if_needed].compact
     automated_report.report_class.constantize.new(*args)
   end
 
@@ -39,13 +40,6 @@ class AutomatedReportInstance < ActiveRecord::Base
     return nil unless needs_step_width?
 
     1
-  end
-
-  def source
-    return nil unless needs_source?
-
-    # TODO: this should be specified for the automated report somewhere
-    'DS'
   end
 
   REPORTS_THAT_NEED_RANGE = %w[

--- a/app/models/federated_login_event.rb
+++ b/app/models/federated_login_event.rb
@@ -3,6 +3,14 @@
 class FederatedLoginEvent < ActiveRecord::Base
   valhammer
 
+  belongs_to :identity_provider,
+             foreign_key: :asserting_party,
+             primary_key: :entity_id
+
+  belongs_to :service_provider,
+             foreign_key: :relying_party,
+             primary_key: :entity_id
+
   scope(:within_range, lambda { |start, finish|
     where(arel_table[:timestamp].gteq(start)
       .and(arel_table[:timestamp].lteq(finish)))

--- a/app/models/federated_login_event.rb
+++ b/app/models/federated_login_event.rb
@@ -3,6 +3,13 @@
 class FederatedLoginEvent < ActiveRecord::Base
   valhammer
 
+  scope(:within_range, lambda { |start, finish|
+    where(arel_table[:timestamp].gteq(start)
+      .and(arel_table[:timestamp].lteq(finish)))
+  })
+
+  scope(:sessions, -> { where(result: 'OK') })
+
   def create_instance(event)
     data = fields(event.data)
     update login_event_hash(data)

--- a/app/reports/daily_demand_report.rb
+++ b/app/reports/daily_demand_report.rb
@@ -8,10 +8,11 @@ class DailyDemandReport < TimeSeriesReport
   units ''
   series sessions: 'Sessions'
 
-  def initialize(start, finish)
+  def initialize(start, finish, source)
     title = 'Daily Demand'
     @start = start
     @finish = finish
+    @source = source
 
     super(title, start: @start, end: @finish)
   end

--- a/app/reports/federated_sessions_report.rb
+++ b/app/reports/federated_sessions_report.rb
@@ -8,11 +8,12 @@ class FederatedSessionsReport < TimeSeriesReport
   units ''
   series sessions: 'Sessions'
 
-  def initialize(start, finish, steps)
+  def initialize(start, finish, steps, source)
     title = 'Federated Sessions'
     @start = start
     @finish = finish
     @steps = steps
+    @source = source
 
     super(title, start: @start, end: @finish)
   end

--- a/app/reports/identity_provider_daily_demand_report.rb
+++ b/app/reports/identity_provider_daily_demand_report.rb
@@ -8,11 +8,12 @@ class IdentityProviderDailyDemandReport < TimeSeriesReport
   units ''
   series sessions: 'Sessions'
 
-  def initialize(entity_id, start, finish)
+  def initialize(entity_id, start, finish, source)
     @identity_provider = IdentityProvider.find_by(entity_id: entity_id)
     title = "IdP Daily Demand Report for #{@identity_provider.name}"
     @start = start
     @finish = finish
+    @source = source
 
     super(title, start: @start, end: @finish)
   end

--- a/app/reports/identity_provider_destination_services_report.rb
+++ b/app/reports/identity_provider_destination_services_report.rb
@@ -7,11 +7,12 @@ class IdentityProviderDestinationServicesReport < TabularReport
   header ['SP Name', 'Total']
   footer
 
-  def initialize(entity_id, start, finish)
+  def initialize(entity_id, start, finish, source)
     @identity_provider = IdentityProvider.find_by(entity_id: entity_id)
     title = "IdP Destination Report for #{@identity_provider.name}"
     @start = start
     @finish = finish
+    @source = source
 
     super(title)
   end

--- a/app/reports/identity_provider_sessions_report.rb
+++ b/app/reports/identity_provider_sessions_report.rb
@@ -8,12 +8,13 @@ class IdentityProviderSessionsReport < TimeSeriesReport
   units ''
   series sessions: 'Sessions'
 
-  def initialize(entity_id, start, finish, steps)
+  def initialize(entity_id, start, finish, steps, source)
     @identity_provider = IdentityProvider.find_by(entity_id: entity_id)
     title = "Identity Provider Sessions for #{@identity_provider.name}"
     @start = start
     @finish = finish
     @steps = steps
+    @source = source
 
     super(title, start: @start, end: @finish)
   end

--- a/app/reports/identity_provider_utilization_report.rb
+++ b/app/reports/identity_provider_utilization_report.rb
@@ -8,10 +8,11 @@ class IdentityProviderUtilizationReport < TabularReport
   header %w[Name Sessions]
   footer
 
-  def initialize(start, finish)
+  def initialize(start, finish, source)
     title = 'Identity Provider Utilization Report'
     @start = start
     @finish = finish
+    @source = source
 
     super(title)
   end

--- a/app/reports/reports_shared_methods.rb
+++ b/app/reports/reports_shared_methods.rb
@@ -79,11 +79,11 @@ module ReportsSharedMethods
   TARGET_OPTS = {
     IdentityProvider => {
       assoc: :identity_provider,
-      foreign_key: :selected_idp
+      foreign_key: { 'DS' => 'selected_idp', 'IdP' => 'asserting_party' }.freeze
     }.freeze,
     ServiceProvider => {
       assoc: :service_provider,
-      foreign_key: :initiating_sp
+      foreign_key: { 'DS' => 'initiating_sp', 'IdP' => 'relying_party' }.freeze
     }.freeze
   }.freeze
 
@@ -92,7 +92,7 @@ module ReportsSharedMethods
 
     session_objects
       .joins(opts[:assoc])
-      .group(opts[:foreign_key])
+      .group(opts[:foreign_key][@source])
       .select(target.arel_table[:name], 'count(*)')
       .to_sql
   end

--- a/app/reports/reports_shared_methods.rb
+++ b/app/reports/reports_shared_methods.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 module ReportsSharedMethods
+  def source_options
+    SESSION_SOURCES.map { |k, v| [v[:name], k] }
+  end
+  module_function :source_options
+
   private
 
   def output_data(range, report, step_width, divider, decimal_places = 1)
@@ -50,8 +55,10 @@ module ReportsSharedMethods
 
   SESSION_SOURCES = {
     'DS' => { klass: DiscoveryServiceEvent,
+              name: 'Discovery Service',
               idp: 'selected_idp', sp: 'initiating_sp' },
     'IdP' => { klass: FederatedLoginEvent,
+               name: 'IdP Event Log',
                idp: 'asserting_party', sp: 'relying_party' }
   }.freeze
 

--- a/app/reports/reports_shared_methods.rb
+++ b/app/reports/reports_shared_methods.rb
@@ -6,6 +6,10 @@ module ReportsSharedMethods
   end
   module_function :source_options
 
+  def source_name
+    SESSION_SOURCES[@source][:name]
+  end
+
   private
 
   def output_data(range, report, step_width, divider, decimal_places = 1)

--- a/app/reports/reports_shared_methods.rb
+++ b/app/reports/reports_shared_methods.rb
@@ -48,17 +48,24 @@ module ReportsSharedMethods
     report[time] ? (report[time].to_f / divider).round(decimal_places) : 0.0
   end
 
+  SESSION_SOURCES = {
+    'DS' => { klass: DiscoveryServiceEvent,
+              idp: 'selected_idp', sp: 'initiating_sp' },
+    'IdP' => { klass: FederatedLoginEvent,
+               idp: 'asserting_party', sp: 'relying_party' }
+  }.freeze
+
   def sessions(where_args = {})
-    DiscoveryServiceEvent
+    SESSION_SOURCES[@source][:klass]
       .within_range(@start, @finish).where(where_args).sessions
   end
 
   def idp_sessions
-    sessions selected_idp: @identity_provider.entity_id
+    sessions(SESSION_SOURCES[@source][:idp] => @identity_provider.entity_id)
   end
 
   def sp_sessions
-    sessions initiating_sp: @service_provider.entity_id
+    sessions(SESSION_SOURCES[@source][:sp] => @service_provider.entity_id)
   end
 
   def tabular_sessions(target, session_objects = sessions)

--- a/app/reports/reports_shared_methods.rb
+++ b/app/reports/reports_shared_methods.rb
@@ -4,7 +4,11 @@ module ReportsSharedMethods
   def source_options
     SESSION_SOURCES.map { |k, v| [v[:name], k] }
   end
-  module_function :source_options
+
+  def source_display_names
+    SESSION_SOURCES.transform_values { |v| v[:name] }.merge(nil => 'N/A')
+  end
+  module_function :source_options, :source_display_names
 
   def source_name
     SESSION_SOURCES[@source][:name]

--- a/app/reports/service_provider_daily_demand_report.rb
+++ b/app/reports/service_provider_daily_demand_report.rb
@@ -8,11 +8,12 @@ class ServiceProviderDailyDemandReport < TimeSeriesReport
   units ''
   series sessions: 'Sessions'
 
-  def initialize(entity_id, start, finish)
+  def initialize(entity_id, start, finish, source)
     @service_provider = ServiceProvider.find_by(entity_id: entity_id)
     title = "SP Daily Demand Report for #{@service_provider.name}"
     @start = start
     @finish = finish
+    @source = source
 
     super(title, start: @start, end: @finish)
   end

--- a/app/reports/service_provider_sessions_report.rb
+++ b/app/reports/service_provider_sessions_report.rb
@@ -8,12 +8,13 @@ class ServiceProviderSessionsReport < TimeSeriesReport
   units ''
   series sessions: 'Sessions'
 
-  def initialize(entity_id, start, finish, steps)
+  def initialize(entity_id, start, finish, steps, source)
     @service_provider = ServiceProvider.find_by(entity_id: entity_id)
     title = "Service Provider Sessions for #{@service_provider.name}"
     @start = start
     @finish = finish
     @steps = steps
+    @source = source
 
     super(title, start: @start, end: @finish)
   end

--- a/app/reports/service_provider_source_identity_providers_report.rb
+++ b/app/reports/service_provider_source_identity_providers_report.rb
@@ -7,11 +7,12 @@ class ServiceProviderSourceIdentityProvidersReport < TabularReport
   header ['IdP Name', 'Total']
   footer
 
-  def initialize(entity_id, start, finish)
+  def initialize(entity_id, start, finish, source)
     @service_provider = ServiceProvider.find_by(entity_id: entity_id)
     title = "SP Source Identity Providers Report for #{@service_provider.name}"
     @start = start
     @finish = finish
+    @source = source
 
     super(title)
   end

--- a/app/reports/service_provider_utilization_report.rb
+++ b/app/reports/service_provider_utilization_report.rb
@@ -8,10 +8,11 @@ class ServiceProviderUtilizationReport < TabularReport
   header %w[Name Sessions]
   footer
 
-  def initialize(start, finish)
+  def initialize(start, finish, source)
     title = 'Service Provider Utilization Report'
     @start = start
     @finish = finish
+    @source = source
 
     super(title)
   end

--- a/app/reports/tabular_report.rb
+++ b/app/reports/tabular_report.rb
@@ -29,6 +29,9 @@ class TabularReport
   end
 
   def generate
-    self.class.options.merge(title: @title, rows: rows)
+    title = @title
+    title += ' (' + source_name + ')' if @source.present?
+
+    self.class.options.merge(title: title, rows: rows)
   end
 end

--- a/app/reports/time_series_report.rb
+++ b/app/reports/time_series_report.rb
@@ -41,7 +41,9 @@ class TimeSeriesReport
 
   def generate
     range = @range.try(:transform_values) { |t| t.strftime('%FT%H:%M:%S%z') }
+    title = @title
+    title += ' (' + source_name + ')' if @source.present?
 
-    self.class.options.merge(title: @title, data: data, range: range).compact
+    self.class.options.merge(title: title, data: data, range: range).compact
   end
 end

--- a/app/views/administrator_reports/_form.html.slim
+++ b/app/views/administrator_reports/_form.html.slim
@@ -1,6 +1,8 @@
 - start_date = @start ? @start : Time.zone.now.beginning_of_month - 1.month
 - end_date = @end ? @end : Time.zone.now.beginning_of_month
-- source = @source ? @source : 'DS'
+- source = @source
+- source = Rails.application.config.reporting_service.default_session_source if source.blank?
+- source = 'DS' if source.blank?
 
 = form_tag({}, id: 'report-form') do
   = field_block do

--- a/app/views/administrator_reports/_form.html.slim
+++ b/app/views/administrator_reports/_form.html.slim
@@ -3,6 +3,7 @@
 - source = @source
 - source = Rails.application.config.reporting_service.default_session_source if source.blank?
 - source = 'DS' if source.blank?
+- source_options = ReportsSharedMethods.source_options
 
 = form_tag({}, id: 'report-form') do
   = field_block do
@@ -22,7 +23,7 @@
       = label_tag(:source) do
         | session data source
 
-      = select_tag :source, options_for_select([[ 'Discovery Service', 'DS'], [ 'IdP event log', 'IdP'] ], source), placeholder: 'select the data source'
+      = select_tag :source, options_for_select(source_options, source), placeholder: 'select the data source'
 
   = button_tag(type: 'submit', class: 'btn-lg btn-primary') do
     => icon_tag('ok')

--- a/app/views/administrator_reports/_form.html.slim
+++ b/app/views/administrator_reports/_form.html.slim
@@ -1,5 +1,6 @@
 - start_date = @start ? @start : Time.zone.now.beginning_of_month - 1.month
 - end_date = @end ? @end : Time.zone.now.beginning_of_month
+- source = @source ? @source : 'DS'
 
 = form_tag({}, id: 'report-form') do
   = field_block do
@@ -13,6 +14,13 @@
       | to
 
     = date_field_tag :end, value = end_date, placeholder: 'click here to pick a date'
+
+  - if not report_class.eql? 'FederationGrowthReport'
+    = field_block do
+      = label_tag(:source) do
+        | session data source
+
+      = select_tag :source, options_for_select([[ 'Discovery Service', 'DS'], [ 'IdP event log', 'IdP'] ], source), placeholder: 'select the data source'
 
   = button_tag(type: 'submit', class: 'btn-lg btn-primary') do
     => icon_tag('ok')

--- a/app/views/administrator_reports/daily_demand_report.html.slim
+++ b/app/views/administrator_reports/daily_demand_report.html.slim
@@ -10,8 +10,8 @@
 
 h1 Daily Demand Report
 
-p Graphs the daily trend of sessions established via AAF's central
-  Discovery Service, highlighting which time of day users are most active
+p Graphs the daily trend of sessions established,
+  highlighting which time of day users are most active
 
 = render(partial: 'form',
          locals: { report_class: 'DailyDemandReport' })

--- a/app/views/administrator_reports/daily_demand_report.html.slim
+++ b/app/views/administrator_reports/daily_demand_report.html.slim
@@ -4,8 +4,9 @@
 = render(partial: 'shared/flash_message',
          locals: { flash_header: 'Successfully Subscribed' })
 
-= render(partial: 'shared/subscribe_form',
-         locals: { target: nil, report_class: 'DailyDemandReport' })
+- if @data
+  = render(partial: 'shared/subscribe_form',
+           locals: { target: nil, report_class: 'DailyDemandReport' })
 
 h1 Daily Demand Report
 

--- a/app/views/administrator_reports/daily_demand_report.html.slim
+++ b/app/views/administrator_reports/daily_demand_report.html.slim
@@ -12,4 +12,5 @@ h1 Daily Demand Report
 p Graphs the daily trend of sessions established via AAF's central
   Discovery Service, highlighting which time of day users are most active
 
-= render(partial: 'form')
+= render(partial: 'form',
+         locals: { report_class: 'DailyDemandReport' })

--- a/app/views/administrator_reports/federated_sessions_report.html.slim
+++ b/app/views/administrator_reports/federated_sessions_report.html.slim
@@ -4,8 +4,9 @@
 = render(partial: 'shared/flash_message',
          locals: { flash_header: 'Successfully Subscribed' })
 
-= render(partial: 'shared/subscribe_form',
-         locals: { target: nil, report_class: 'FederatedSessionsReport' })
+- if @data
+  = render(partial: 'shared/subscribe_form',
+           locals: { target: nil, report_class: 'FederatedSessionsReport' })
 
 h1 Federated Sessions Report
 

--- a/app/views/administrator_reports/federated_sessions_report.html.slim
+++ b/app/views/administrator_reports/federated_sessions_report.html.slim
@@ -10,8 +10,7 @@
 
 h1 Federated Sessions Report
 
-p Graphs the hourly number of sessions established via AAF's central
-  Discovery Service
+p Graphs the hourly number of sessions established
 
 = render(partial: 'form',
          locals: { report_class: 'FederatedSessionsReport' })

--- a/app/views/administrator_reports/federated_sessions_report.html.slim
+++ b/app/views/administrator_reports/federated_sessions_report.html.slim
@@ -12,4 +12,5 @@ h1 Federated Sessions Report
 p Graphs the hourly number of sessions established via AAF's central
   Discovery Service
 
-= render(partial: 'form')
+= render(partial: 'form',
+         locals: { report_class: 'FederatedSessionsReport' })

--- a/app/views/administrator_reports/federation_growth_report.html.slim
+++ b/app/views/administrator_reports/federation_growth_report.html.slim
@@ -13,4 +13,5 @@ p Shows the growth of the federation within a time range, in number of
   Organisations, Service Providers, Identity Providers and Rapid Connect
   Services
 
-= render(partial: 'form')
+= render(partial: 'form',
+         locals: { report_class: 'FederationGrowthReport' })

--- a/app/views/administrator_reports/identity_provider_utilization_report.html.slim
+++ b/app/views/administrator_reports/identity_provider_utilization_report.html.slim
@@ -4,9 +4,10 @@
 = render(partial: 'shared/flash_message',
          locals: { flash_header: 'Successfully Subscribed' })
 
-= render(partial: 'shared/subscribe_form',
-         locals: { target: nil,
-                   report_class: 'IdentityProviderUtilizationReport' })
+- if @data
+  = render(partial: 'shared/subscribe_form',
+           locals: { target: nil,
+                     report_class: 'IdentityProviderUtilizationReport' })
 
 h1 Identity Provider Utilization Report
 

--- a/app/views/administrator_reports/identity_provider_utilization_report.html.slim
+++ b/app/views/administrator_reports/identity_provider_utilization_report.html.slim
@@ -12,4 +12,5 @@ h1 Identity Provider Utilization Report
 
 p Shows the total number of sessions for each identity provider during the given date range
 
-= render(partial: 'form')
+= render(partial: 'form',
+         locals: { report_class: 'IdentityProviderUtilizationReport' })

--- a/app/views/administrator_reports/index.html.slim
+++ b/app/views/administrator_reports/index.html.slim
@@ -18,14 +18,13 @@ h1 Admin Reports
   = link_to(admin_daily_demand_report_path, class: 'list-group-item') do
     h4.list-group-item-heading Daily Demand Report
     p.list-group-item-text
-      | Graphs the daily trend of sessions established via AAF's central
-        Discovery Service, highlighting which time of day users are most active
+      | Graphs the daily trend of sessions established,
+        highlighting which time of day users are most active
 
   = link_to(admin_federated_sessions_report_path, class: 'list-group-item') do
     h4.list-group-item-heading Federated Sessions Report
     p.list-group-item-text
-      | Graphs the hourly number of sessions established via AAF's central
-        Discovery Service
+      | Graphs the hourly number of sessions established
 
   = link_to(admin_identity_provider_utilization_report_path, class: 'list-group-item') do
     h4.list-group-item-heading Identity Provider Utilization Report

--- a/app/views/administrator_reports/service_provider_utilization_report.html.slim
+++ b/app/views/administrator_reports/service_provider_utilization_report.html.slim
@@ -4,9 +4,10 @@
 = render(partial: 'shared/flash_message',
          locals: { flash_header: 'Successfully Subscribed' })
 
-= render(partial: 'shared/subscribe_form',
-         locals: { target: nil,
-                   report_class: 'ServiceProviderUtilizationReport' })
+- if @data
+  = render(partial: 'shared/subscribe_form',
+           locals: { target: nil,
+                     report_class: 'ServiceProviderUtilizationReport' })
 
 h1 Service Provider Utilization Report
 

--- a/app/views/administrator_reports/service_provider_utilization_report.html.slim
+++ b/app/views/administrator_reports/service_provider_utilization_report.html.slim
@@ -12,4 +12,5 @@ h1 Service Provider Utilization Report
 
 p Shows the total number of sessions for each service provider during the given date range
 
-= render(partial: 'form')
+= render(partial: 'form',
+         locals: { report_class: 'ServiceProviderUtilizationReport' })

--- a/app/views/automated_reports/index.html.slim
+++ b/app/views/automated_reports/index.html.slim
@@ -1,3 +1,4 @@
+- source_display_names = ReportsSharedMethods.source_display_names
 = breadcrumbs({ 'Dashboard' => dashboard_path },
                 'Subscriptions')
 
@@ -14,6 +15,7 @@
   - objects = @subscriptions.map do |s|
     - { report_type: s.automated_report.report_class,
         name: s.automated_report.target_name,
+        source: s.automated_report.source,
         interval: s.automated_report.interval,
         identifier: s.identifier }
 
@@ -23,6 +25,7 @@
       tr
         th Report Type
         th Report Target
+        th Session Data Source
         th Interval
         th Action
 
@@ -37,6 +40,7 @@
             a title=s[:name]
               = name
 
+          td= source_display_names[s[:source]]
           td= s[:interval]
           td
             .dropdown

--- a/app/views/dashboard/index.html.slim
+++ b/app/views/dashboard/index.html.slim
@@ -13,14 +13,13 @@ h1 Federation Reports
   = link_to(public_federated_sessions_report_path, class: 'list-group-item') do
     h4.list-group-item-heading Federated Sessions Report
     p.list-group-item-text
-      | Graphs the hourly number of sessions established via AAF's central
-        Discovery Service
+      | Graphs the hourly number of sessions established
 
   = link_to(public_daily_demand_report_path, class: 'list-group-item') do
     h4.list-group-item-heading Daily Demand Report
     p.list-group-item-text
-      | Graphs the daily trend of sessions established via AAF's central
-        Discovery Service, highlighting which time of day users are most active
+      | Graphs the daily trend of sessions established,
+        highlighting which time of day users are most active
 
 h1 Compliance Reports
 

--- a/app/views/federation_reports/daily_demand_report.html.slim
+++ b/app/views/federation_reports/daily_demand_report.html.slim
@@ -9,7 +9,7 @@
 
 h1 Daily Demand Report
 
-p Graphs the daily trend of sessions established via AAF's central
-  Discovery Service, highlighting which time of day users are most active
+p Graphs the daily trend of sessions established,
+  highlighting which time of day users are most active
 
 = render(partial: 'shared/report_output', locals: { data: @data })

--- a/app/views/federation_reports/federated_sessions_report.html.slim
+++ b/app/views/federation_reports/federated_sessions_report.html.slim
@@ -9,8 +9,7 @@
 
 h1 Federated Sessions Report
 
-p Graphs the hourly number of sessions established via AAF's central
-  Discovery Service
+p Graphs the hourly number of sessions established
 
 = render(partial: 'shared/report_output', locals: { data: @data })
 

--- a/app/views/identity_provider_reports/daily_demand_report.html.slim
+++ b/app/views/identity_provider_reports/daily_demand_report.html.slim
@@ -11,7 +11,7 @@
 
 h1 Identity Provider Daily Demand  Report
 
-p Graphs the daily trend of sessions established for an Identity Provider via AAF's central
-  Discovery Service, highlighting which time of day users are most active
+p Graphs the daily trend of sessions established for an Identity Provider,
+  highlighting which time of day users are most active
 
 = render(partial: 'form')

--- a/app/views/identity_provider_reports/sessions_report.html.slim
+++ b/app/views/identity_provider_reports/sessions_report.html.slim
@@ -12,6 +12,6 @@
 h1 Identity Provider Sessions Report
 
 p Graphs the hourly number of sessions established for an
-  Identity Provider via AAF's central Discovery Service
+  Identity Provider
 
 = render(partial: 'form')

--- a/app/views/service_provider_reports/daily_demand_report.html.slim
+++ b/app/views/service_provider_reports/daily_demand_report.html.slim
@@ -11,8 +11,7 @@
 
 h1 Service Provider Daily Demand  Report
 
-p Graphs the daily trend of sessions initiated with a Service Provider via
-  AAF's central Discovery Service, highlighting which time of day services
-  are most requested
+p Graphs the daily trend of sessions initiated with a Service Provider,
+  highlighting which time of day services are most requested
 
 = render(partial: 'form')

--- a/app/views/service_provider_reports/sessions_report.html.slim
+++ b/app/views/service_provider_reports/sessions_report.html.slim
@@ -11,7 +11,6 @@
 
 h1 Service Provider Sessions Report
 
-p Graphs the hourly number of sessions initiated with a Service Provider via AAF's
-  central Discovery Service
+p Graphs the hourly number of sessions initiated with a Service Provider
 
 = render(partial: 'form')

--- a/app/views/shared/_subscribe_form.html.slim
+++ b/app/views/shared/_subscribe_form.html.slim
@@ -1,5 +1,5 @@
 - action_url = { action: :subscribe, controller: :automated_reports,
-                 target: target, report_class: report_class }
+                 target: target, report_class: report_class, source: @source }
 
 .dropdown
   button.btn.btn-lg.btn-default { aria-expanded="false" aria-haspopup="true"

--- a/app/views/shared/_subscriber_report_form.html.slim
+++ b/app/views/shared/_subscriber_report_form.html.slim
@@ -1,5 +1,7 @@
 - start_date = @start ? @start : Time.zone.now.beginning_of_month - 1.month
 - end_date = @end ? @end : Time.zone.now.beginning_of_month
+- source = @source ? @source : 'DS'
+
 
 = form_tag({}, id: 'report-form') do
     = field_block do
@@ -23,6 +25,12 @@
         | to
 
       = date_field_tag :end, value = end_date, placeholder: 'click here to pick a date'
+
+    = field_block do
+      = label_tag(:source) do
+       | session data source
+
+      = select_tag :source, options_for_select([[ 'Discovery Service', 'DS'], [ 'IdP event log', 'IdP'] ], source), placeholder: 'select the data source'
 
     = button_tag(type: 'submit', class: 'btn-lg btn-primary') do
       => icon_tag('ok')

--- a/app/views/shared/_subscriber_report_form.html.slim
+++ b/app/views/shared/_subscriber_report_form.html.slim
@@ -1,6 +1,8 @@
 - start_date = @start ? @start : Time.zone.now.beginning_of_month - 1.month
 - end_date = @end ? @end : Time.zone.now.beginning_of_month
-- source = @source ? @source : 'DS'
+- source = @source
+- source = Rails.application.config.reporting_service.default_session_source if source.blank?
+- source = 'DS' if source.blank?
 
 
 = form_tag({}, id: 'report-form') do

--- a/app/views/shared/_subscriber_report_form.html.slim
+++ b/app/views/shared/_subscriber_report_form.html.slim
@@ -3,7 +3,7 @@
 - source = @source
 - source = Rails.application.config.reporting_service.default_session_source if source.blank?
 - source = 'DS' if source.blank?
-
+- source_options = ReportsSharedMethods.source_options
 
 = form_tag({}, id: 'report-form') do
     = field_block do
@@ -32,7 +32,7 @@
       = label_tag(:source) do
        | session data source
 
-      = select_tag :source, options_for_select([[ 'Discovery Service', 'DS'], [ 'IdP event log', 'IdP'] ], source), placeholder: 'select the data source'
+      = select_tag :source, options_for_select(source_options, source), placeholder: 'select the data source'
 
     = button_tag(type: 'submit', class: 'btn-lg btn-primary') do
       => icon_tag('ok')

--- a/app/views/subscriber_reports_dashboard/index.html.slim
+++ b/app/views/subscriber_reports_dashboard/index.html.slim
@@ -6,14 +6,13 @@ h1 Identity Provider Reports
   = link_to(identity_provider_sessions_report_path, class: 'list-group-item') do
     h4.list-group-item-heading Identity Provider Sessions Report
     p.list-group-item-text
-      | Graphs the hourly number of sessions established for an Identity Provider via AAF's central
-        Discovery Service
+      | Graphs the hourly number of sessions established for an Identity Provider
 
   = link_to(identity_provider_daily_demand_report_path, class: 'list-group-item') do
     h4.list-group-item-heading Identity Provider Daily Demand Report
     p.list-group-item-text
-      | Graphs the daily trend of sessions established for an Identity Provider via AAF's central
-        Discovery Service, highlighting which time of day users are most active
+      | Graphs the daily trend of sessions established for an Identity Provider,
+        highlighting which time of day users are most active
 
   = link_to(identity_provider_destination_services_report_path, class: 'list-group-item') do
     h4.list-group-item-heading Identity Provider Destination Services Report
@@ -26,14 +25,13 @@ h1 Service Provider Reports
   = link_to(service_provider_sessions_report_path, class: 'list-group-item') do
     h4.list-group-item-heading Service Provider Sessions Report
     p.list-group-item-text
-      | Graphs the hourly number of sessions initiated with a Service Provider via AAF's central
-        Discovery Service
+      | Graphs the hourly number of sessions initiated with a Service Provider
 
   = link_to(service_provider_daily_demand_report_path, class: 'list-group-item') do
     h4.list-group-item-heading Service Provider Daily Demand Report
     p.list-group-item-text
-      | Graphs the daily trend of sessions initiated with a Service Provider via AAF's central
-        Discovery Service, highlighting which time of day services are most requested
+      | Graphs the daily trend of sessions initiated with a Service Provider,
+        highlighting which time of day services are most requested
 
   = link_to(service_provider_source_identity_providers_report_path, class: 'list-group-item') do
     h4.list-group-item-heading Service Provider Source Identity Providers Report

--- a/config/initializers/app_config.rb
+++ b/config/initializers/app_config.rb
@@ -7,6 +7,9 @@ Rails.application.configure do
   app_config = YAML.safe_load(app_config_file.read)
   config.reporting_service = OpenStruct.new(app_config.deep_symbolize_keys)
 
+  mail_config = config.reporting_service.mail
+  Mail.defaults { delivery_method :smtp, mail_config }
+
   if Rails.env.test?
     config.reporting_service.ide = {
       host: 'ide.example.edu',

--- a/config/reporting_service.yml.dist
+++ b/config/reporting_service.yml.dist
@@ -2,7 +2,7 @@
 mail:
   from: noreply@example.com
   port: 1025
-  host: localhost
+  address: localhost
 environment_string: Development
 ide:
   host: ide.test.aaf.edu.au

--- a/config/reporting_service.yml.dist
+++ b/config/reporting_service.yml.dist
@@ -24,6 +24,7 @@ sqs:
   encryption_key: config/event_encryption_key.pem
   queues:
     discovery: http://localhost:9324/queue/discovery-service-development
+default_session_source: 'DS'
 url_options:
   base_url: 'http://localhost:8080'
 time_zone: Australia/Brisbane

--- a/db/migrate/20170512043336_add_source_to_automated_report.rb
+++ b/db/migrate/20170512043336_add_source_to_automated_report.rb
@@ -1,0 +1,5 @@
+class AddSourceToAutomatedReport < ActiveRecord::Migration[5.0]
+  def change
+    add_column :automated_reports, :source, :string
+  end
+end

--- a/db/migrate/20170512043336_add_source_to_automated_report.rb
+++ b/db/migrate/20170512043336_add_source_to_automated_report.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddSourceToAutomatedReport < ActiveRecord::Migration[5.0]
   def change
     add_column :automated_reports, :source, :string

--- a/db/migrate/20170516001834_add_index_to_federated_login_event.rb
+++ b/db/migrate/20170516001834_add_index_to_federated_login_event.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddIndexToFederatedLoginEvent < ActiveRecord::Migration[5.0]
+  def change
+    add_index :federated_login_events, %i[result timestamp]
+  end
+end

--- a/db/migrate/20170516001834_add_index_to_federated_login_event.rb
+++ b/db/migrate/20170516001834_add_index_to_federated_login_event.rb
@@ -2,6 +2,6 @@
 
 class AddIndexToFederatedLoginEvent < ActiveRecord::Migration[5.0]
   def change
-    add_index :federated_login_events, %i[result timestamp]
+    add_index :federated_login_events, %i[result timestamp], using: :btree
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160613235908) do
+ActiveRecord::Schema.define(version: 20170512043336) do
 
   create_table "activations", force: :cascade do |t|
     t.integer  "federation_object_id",   limit: 4,   null: false
@@ -75,6 +75,7 @@ ActiveRecord::Schema.define(version: 20160613235908) do
     t.datetime "created_at",                      null: false
     t.datetime "updated_at",                      null: false
     t.datetime "instances_timestamp"
+    t.string   "source",              limit: 255
   end
 
   create_table "discovery_service_events", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170512043336) do
+ActiveRecord::Schema.define(version: 20170516001834) do
 
   create_table "activations", force: :cascade do |t|
     t.integer  "federation_object_id",   limit: 4,   null: false
@@ -107,6 +107,7 @@ ActiveRecord::Schema.define(version: 20170512043336) do
   end
 
   add_index "federated_login_events", ["hashed_principal_name"], name: "index_federated_login_events_on_hashed_principal_name", using: :btree
+  add_index "federated_login_events", ["result", "timestamp"], name: "index_federated_login_events_on_result_and_timestamp", using: :btree
 
   create_table "identity_provider_saml_attributes", force: :cascade do |t|
     t.integer  "identity_provider_id", limit: 4, null: false

--- a/spec/controllers/administrator_reports_controller_spec.rb
+++ b/spec/controllers/administrator_reports_controller_spec.rb
@@ -10,6 +10,11 @@ RSpec.describe AdministratorReportsController, type: :controller do
       end: Time.now.utc }
   end
 
+  let(:source) do
+    # TODO: test with other sources?
+    { source: 'DS' }
+  end
+
   subject { response }
 
   before { session[:subject_id] = user.try(:id) }
@@ -57,7 +62,7 @@ RSpec.describe AdministratorReportsController, type: :controller do
   end
 
   context 'generate Daily Demand Report' do
-    let(:params) { range }
+    let(:params) { range.merge(source) }
     let(:template) { 'daily-demand' }
     let(:action) { 'daily_demand_report' }
 
@@ -65,7 +70,7 @@ RSpec.describe AdministratorReportsController, type: :controller do
   end
 
   context 'generate Federated Sessions Report' do
-    let(:params) { range }
+    let(:params) { range.merge(source) }
     let(:template) { 'federated-sessions' }
     let(:action) { 'federated_sessions_report' }
 
@@ -73,14 +78,14 @@ RSpec.describe AdministratorReportsController, type: :controller do
   end
 
   context 'steps should scale correctly' do
-    let(:params) { {} }
+    let(:params) { source }
     let(:path) { :federated_sessions_report }
 
     it_behaves_like 'report with scalable steps'
   end
 
   context 'generate Identity Provider Utilization Report' do
-    let(:params) { range }
+    let(:params) { range.merge(source) }
     let(:template) { 'identity-provider-utilization' }
     let(:action) { 'identity_provider_utilization_report' }
 
@@ -88,7 +93,7 @@ RSpec.describe AdministratorReportsController, type: :controller do
   end
 
   context 'generate Service Provider Utilization Report' do
-    let(:params) { range }
+    let(:params) { range.merge(source) }
     let(:template) { 'service-provider-utilization' }
     let(:action) { 'service_provider_utilization_report' }
 

--- a/spec/controllers/automated_report_instances_controller_spec.rb
+++ b/spec/controllers/automated_report_instances_controller_spec.rb
@@ -34,7 +34,8 @@ RSpec.describe AutomatedReportInstancesController, type: :controller do
     let(:auto_report) do
       create :automated_report,
              target: target,
-             report_class: report_class
+             report_class: report_class,
+             source: source
     end
 
     let!(:instance) do
@@ -57,6 +58,7 @@ RSpec.describe AutomatedReportInstancesController, type: :controller do
 
   context 'Federation Growth Report' do
     let(:report_class) { 'FederationGrowthReport' }
+    let(:source) { nil }
     let(:target) { nil }
 
     it_behaves_like 'Automated Public Report'
@@ -64,6 +66,7 @@ RSpec.describe AutomatedReportInstancesController, type: :controller do
 
   context 'Federated Sessions Report' do
     let(:report_class) { 'FederatedSessionsReport' }
+    let(:source) { 'DS' }
     let(:target) { nil }
 
     it_behaves_like 'Automated Public Report'
@@ -71,6 +74,7 @@ RSpec.describe AutomatedReportInstancesController, type: :controller do
 
   context 'Daily Demand Report' do
     let(:report_class) { 'DailyDemandReport' }
+    let(:source) { 'DS' }
     let(:target) { nil }
 
     it_behaves_like 'Automated Public Report'
@@ -78,6 +82,7 @@ RSpec.describe AutomatedReportInstancesController, type: :controller do
 
   context 'Identity Provider Attributes Report' do
     let(:report_class) { 'IdentityProviderAttributesReport' }
+    let(:source) { nil }
     let(:target) { nil }
 
     it_behaves_like 'Automated Public Report'
@@ -85,6 +90,7 @@ RSpec.describe AutomatedReportInstancesController, type: :controller do
 
   context 'Provided Attribute Report Report' do
     let(:report_class) { 'ProvidedAttributeReport' }
+    let(:source) { nil }
     let(:target) { attribute.name }
 
     it_behaves_like 'Automated Public Report'
@@ -92,6 +98,7 @@ RSpec.describe AutomatedReportInstancesController, type: :controller do
 
   context 'Requested Attribute Report' do
     let(:report_class) { 'RequestedAttributeReport' }
+    let(:source) { nil }
     let(:target) { attribute.name }
 
     it_behaves_like 'Automated Public Report'
@@ -99,6 +106,7 @@ RSpec.describe AutomatedReportInstancesController, type: :controller do
 
   context 'Automated Federation Service Compatibility Report' do
     let(:target) { sp.entity_id }
+    let(:source) { nil }
     let(:report_class) { 'ServiceCompatibilityReport' }
 
     it_behaves_like 'Automated Public Report'
@@ -108,7 +116,8 @@ RSpec.describe AutomatedReportInstancesController, type: :controller do
     let(:auto_report) do
       create :automated_report,
              target: object.entity_id,
-             report_class: report_class
+             report_class: report_class,
+             source: source
     end
 
     let!(:instance) do
@@ -119,7 +128,8 @@ RSpec.describe AutomatedReportInstancesController, type: :controller do
     let!(:unknown_auto_report) do
       create :automated_report,
              target: unknown_object.entity_id,
-             report_class: report_class
+             report_class: report_class,
+             source: source
     end
 
     let!(:unknown_instance) do
@@ -170,6 +180,7 @@ RSpec.describe AutomatedReportInstancesController, type: :controller do
 
   context 'Identity Provider Sessions Report' do
     let(:report_class) { 'IdentityProviderSessionsReport' }
+    let(:source) { 'DS' }
     let(:object) { idp }
     let(:unknown_object) { unknown_idp }
 
@@ -178,6 +189,7 @@ RSpec.describe AutomatedReportInstancesController, type: :controller do
 
   context 'Identity Provider Daily Demand Report' do
     let(:report_class) { 'IdentityProviderDailyDemandReport' }
+    let(:source) { 'DS' }
     let(:object) { idp }
     let(:unknown_object) { unknown_idp }
 
@@ -186,6 +198,7 @@ RSpec.describe AutomatedReportInstancesController, type: :controller do
 
   context 'Identity Provider Destination Services Report' do
     let(:report_class) { 'IdentityProviderDestinationServicesReport' }
+    let(:source) { 'DS' }
     let(:object) { idp }
     let(:unknown_object) { unknown_idp }
 
@@ -194,6 +207,7 @@ RSpec.describe AutomatedReportInstancesController, type: :controller do
 
   context 'Service Provider Sessions Report' do
     let(:report_class) { 'ServiceProviderSessionsReport' }
+    let(:source) { 'DS' }
     let(:object) { sp }
     let(:unknown_object) { unknown_sp }
 
@@ -202,6 +216,7 @@ RSpec.describe AutomatedReportInstancesController, type: :controller do
 
   context 'Service Provider Daily Demand Report' do
     let(:report_class) { 'ServiceProviderDailyDemandReport' }
+    let(:source) { 'DS' }
     let(:object) { sp }
     let(:unknown_object) { unknown_sp }
 
@@ -210,6 +225,7 @@ RSpec.describe AutomatedReportInstancesController, type: :controller do
 
   context 'Service Provider Source Identity Providers Report' do
     let(:report_class) { 'ServiceProviderSourceIdentityProvidersReport' }
+    let(:source) { 'DS' }
     let(:object) { sp }
     let(:unknown_object) { unknown_sp }
 

--- a/spec/controllers/automated_reports_controller_spec.rb
+++ b/spec/controllers/automated_reports_controller_spec.rb
@@ -15,8 +15,9 @@ RSpec.describe AutomatedReportsController, type: :controller do
 
     post :subscribe, params: {
       report_class: report_class, interval: interval,
+      source: source,
       back_path: request.env['HTTP_REFERER']
-    }
+    }.compact
   end
 
   before do
@@ -33,6 +34,7 @@ RSpec.describe AutomatedReportsController, type: :controller do
     let(:auto_report) do
       create :automated_report,
              report_class: 'IdentityProviderSessionsReport',
+             source: 'DS',
              target: idp.entity_id
     end
 
@@ -83,6 +85,7 @@ RSpec.describe AutomatedReportsController, type: :controller do
   context 'Federation Growth Report' do
     let(:path) { 'federation_growth_report' }
     let(:report_class) { 'FederationGrowthReport' }
+    let(:source) { nil }
     let(:template) { 'svg.federation-growth' }
 
     it_behaves_like 'Automated Report Subscription'
@@ -91,6 +94,7 @@ RSpec.describe AutomatedReportsController, type: :controller do
   context 'Federated Sessions Report' do
     let(:path) { 'federated_sessions' }
     let(:report_class) { 'FederatedSessionsReport' }
+    let(:source) { 'DS' }
     let(:template) { 'svg.federated-sessions' }
 
     it_behaves_like 'Automated Report Subscription'
@@ -99,6 +103,7 @@ RSpec.describe AutomatedReportsController, type: :controller do
   context 'Daily Demand Report' do
     let(:path) { 'daily_demand_report' }
     let(:report_class) { 'DailyDemandReport' }
+    let(:source) { 'DS' }
     let(:template) { 'svg.daily-demand_report' }
 
     it_behaves_like 'Automated Report Subscription'

--- a/spec/factories/automated_report.rb
+++ b/spec/factories/automated_report.rb
@@ -2,7 +2,7 @@
 
 FactoryGirl.define do
   factory :automated_report do
-    report_class 'DailyDemandReport'
+    report_class 'FederationGrowthReport'
     interval 'monthly'
   end
 end

--- a/spec/factories/federated_login_event.rb
+++ b/spec/factories/federated_login_event.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+FactoryGirl.define do
+  factory :federated_login_event do
+    hashed_principal_name { Faker::Internet.password(10) }
+    result { 'FAIL' }
+    relying_party do
+      "https://sp.#{Faker::Internet.domain_name}/shibboleth"
+    end
+
+    timestamp do
+      Faker::Time.between(10.days.ago, Time.zone.today, :day)
+    end
+
+    trait :OK do
+      asserting_party do
+        "https://idp.#{Faker::Internet.domain_name}/idp/shibboleth"
+      end
+
+      result { 'OK' }
+    end
+  end
+end

--- a/spec/factories/federated_login_event.rb
+++ b/spec/factories/federated_login_event.rb
@@ -8,15 +8,15 @@ FactoryGirl.define do
       "https://sp.#{Faker::Internet.domain_name}/shibboleth"
     end
 
+    asserting_party do
+      "https://idp.#{Faker::Internet.domain_name}/idp/shibboleth"
+    end
+
     timestamp do
       Faker::Time.between(10.days.ago, Time.zone.today, :day)
     end
 
     trait :OK do
-      asserting_party do
-        "https://idp.#{Faker::Internet.domain_name}/idp/shibboleth"
-      end
-
       result { 'OK' }
     end
   end

--- a/spec/features/administrator_reports_spec.rb
+++ b/spec/features/administrator_reports_spec.rb
@@ -87,64 +87,100 @@ RSpec.feature 'Administrator Reports' do
       end
     end
 
-    context 'Daily Demand Report' do
+    shared_examples 'Daily Demand Report' do
       scenario 'viewing Report' do
         click_link 'Daily Demand Report'
 
         fill_in 'start', with: Time.now.utc.beginning_of_month - 1.month
         fill_in 'end', with: Time.now.utc.beginning_of_month
+        select data_source_name, from: 'source'
 
         click_button('Generate')
 
         expect(current_path)
           .to eq('/admin_reports/daily_demand_report')
         expect(page).to have_css('svg.daily-demand')
+        expect(page).to have_content("(#{data_source_name})")
       end
     end
 
-    context 'Federated Sessions Report' do
+    shared_examples 'Federated Sessions Report' do
       scenario 'viewing Report' do
         click_link 'Federated Sessions Report'
 
         fill_in 'start', with: Time.now.utc.beginning_of_month - 1.month
         fill_in 'end', with: Time.now.utc.beginning_of_month
+        select data_source_name, from: 'source'
 
         click_button('Generate')
 
         expect(current_path)
           .to eq('/admin_reports/federated_sessions_report')
         expect(page).to have_css('svg.federated-sessions')
+        expect(page).to have_content("(#{data_source_name})")
       end
     end
 
-    context 'Identity Provider Utilization Report' do
+    shared_examples 'Identity Provider Utilization Report' do
       scenario 'viewing Report' do
         click_link 'Identity Provider Utilization Report'
 
         fill_in 'start', with: Time.now.utc.beginning_of_month - 1.month
         fill_in 'end', with: Time.now.utc.beginning_of_month
+        select data_source_name, from: 'source'
 
         click_button('Generate')
 
         expect(current_path)
           .to eq('/admin_reports/identity_provider_utilization_report')
         expect(page).to have_css('table.identity-provider-utilization')
+        # Tabular reports do not render report title - see #178
+        # So instead just confirm the report-data JSON contains the title.
+        report_data = page.evaluate_script(
+          'document.getElementsByClassName("report-data")[0].innerHTML'
+        )
+        expect(report_data).to have_text("(#{data_source_name})")
       end
     end
 
-    context 'Service Provider Utilization Report' do
+    shared_examples 'Service Provider Utilization Report' do
       scenario 'viewing Report' do
         click_link 'Service Provider Utilization Report'
 
         fill_in 'start', with: Time.now.utc.beginning_of_month - 1.month
         fill_in 'end', with: Time.now.utc.beginning_of_month
+        select data_source_name, from: 'source'
 
         click_button('Generate')
 
         expect(current_path)
           .to eq('/admin_reports/service_provider_utilization_report')
         expect(page).to have_css('table.service-provider-utilization')
+        # Tabular reports do not render report title - see #178
+        # So instead just confirm the report-data JSON contains the title.
+        report_data = page.evaluate_script(
+          'document.getElementsByClassName("report-data")[0].innerHTML'
+        )
+        expect(report_data).to have_text("(#{data_source_name})")
       end
+    end
+
+    context 'selecting DS session data source' do
+      let(:data_source_name) { 'Discovery Service' }
+
+      it_behaves_like 'Daily Demand Report'
+      it_behaves_like 'Federated Sessions Report'
+      it_behaves_like 'Identity Provider Utilization Report'
+      it_behaves_like 'Service Provider Utilization Report'
+    end
+
+    context 'selecting IdP session data source' do
+      let(:data_source_name) { 'IdP Event Log' }
+
+      it_behaves_like 'Daily Demand Report'
+      it_behaves_like 'Federated Sessions Report'
+      it_behaves_like 'Identity Provider Utilization Report'
+      it_behaves_like 'Service Provider Utilization Report'
     end
   end
 end

--- a/spec/features/automated_report_instances_spec.rb
+++ b/spec/features/automated_report_instances_spec.rb
@@ -26,7 +26,8 @@ RSpec.feature 'automated report instances' do
     given(:auto_report) do
       create :automated_report,
              target: target,
-             report_class: report_class
+             report_class: report_class,
+             source: source
     end
 
     given!(:instance) do
@@ -56,6 +57,7 @@ RSpec.feature 'automated report instances' do
 
   context 'Federation Growth Report' do
     given(:report_class) { 'FederationGrowthReport' }
+    given(:source) { nil }
     given(:target) { nil }
 
     it_behaves_like 'Automated Public Report'
@@ -63,6 +65,7 @@ RSpec.feature 'automated report instances' do
 
   context 'Federated Sessions Report' do
     given(:report_class) { 'FederatedSessionsReport' }
+    given(:source) { 'DS' }
     given(:target) { nil }
 
     it_behaves_like 'Automated Public Report'
@@ -70,6 +73,7 @@ RSpec.feature 'automated report instances' do
 
   context 'Daily Demand Report' do
     given(:report_class) { 'DailyDemandReport' }
+    given(:source) { 'DS' }
     given(:target) { nil }
 
     it_behaves_like 'Automated Public Report'
@@ -77,6 +81,7 @@ RSpec.feature 'automated report instances' do
 
   context 'Identity Provider Attributes Report' do
     given(:report_class) { 'IdentityProviderAttributesReport' }
+    given(:source) { nil }
     given(:target) { nil }
 
     it_behaves_like 'Automated Public Report'
@@ -84,6 +89,7 @@ RSpec.feature 'automated report instances' do
 
   context 'Provided Attribute Report Report' do
     given(:report_class) { 'ProvidedAttributeReport' }
+    given(:source) { nil }
     given(:target) { attribute.name }
 
     it_behaves_like 'Automated Public Report'
@@ -91,6 +97,7 @@ RSpec.feature 'automated report instances' do
 
   context 'Requested Attribute Report' do
     given(:report_class) { 'RequestedAttributeReport' }
+    given(:source) { nil }
     given(:target) { attribute.name }
 
     it_behaves_like 'Automated Public Report'
@@ -99,6 +106,7 @@ RSpec.feature 'automated report instances' do
   context 'Automated Federation Service Compatibility Report' do
     given(:target) { sp.entity_id }
     given(:report_class) { 'ServiceCompatibilityReport' }
+    given(:source) { nil }
 
     it_behaves_like 'Automated Public Report'
   end
@@ -107,7 +115,8 @@ RSpec.feature 'automated report instances' do
     given(:auto_report) do
       create :automated_report,
              target: object.entity_id,
-             report_class: report_class
+             report_class: report_class,
+             source: source
     end
 
     given!(:instance) do
@@ -118,7 +127,8 @@ RSpec.feature 'automated report instances' do
     given!(:unknown_auto_report) do
       create :automated_report,
              target: unknown_object.entity_id,
-             report_class: report_class
+             report_class: report_class,
+             source: source
     end
 
     given!(:unknown_instance) do
@@ -161,6 +171,7 @@ RSpec.feature 'automated report instances' do
 
   context 'Identity Provider Sessions Report' do
     given(:report_class) { 'IdentityProviderSessionsReport' }
+    given(:source) { 'DS' }
     given(:object) { idp }
     given(:unknown_object) { unknown_idp }
 
@@ -169,6 +180,7 @@ RSpec.feature 'automated report instances' do
 
   context 'Identity Provider Daily Demand Report' do
     given(:report_class) { 'IdentityProviderDailyDemandReport' }
+    given(:source) { 'DS' }
     given(:object) { idp }
     given(:unknown_object) { unknown_idp }
 
@@ -177,6 +189,7 @@ RSpec.feature 'automated report instances' do
 
   context 'Identity Provider Destination Services Report' do
     given(:report_class) { 'IdentityProviderDestinationServicesReport' }
+    given(:source) { 'DS' }
     given(:object) { idp }
     given(:unknown_object) { unknown_idp }
 
@@ -185,6 +198,7 @@ RSpec.feature 'automated report instances' do
 
   context 'Service Provider Source Identity Providers Report' do
     given(:report_class) { 'ServiceProviderSourceIdentityProvidersReport' }
+    given(:source) { 'DS' }
     given(:object) { sp }
     given(:unknown_object) { unknown_sp }
 
@@ -193,6 +207,7 @@ RSpec.feature 'automated report instances' do
 
   context 'Service Provider Sessions Report' do
     given(:report_class) { 'ServiceProviderSessionsReport' }
+    given(:source) { 'DS' }
     given(:object) { sp }
     given(:unknown_object) { unknown_sp }
 
@@ -201,6 +216,7 @@ RSpec.feature 'automated report instances' do
 
   context 'Service Provider Daily Demand Report' do
     given(:report_class) { 'ServiceProviderDailyDemandReport' }
+    given(:source) { 'DS' }
     given(:object) { sp }
     given(:unknown_object) { unknown_sp }
 

--- a/spec/features/automated_report_instances_spec.rb
+++ b/spec/features/automated_report_instances_spec.rb
@@ -53,9 +53,7 @@ RSpec.feature 'automated report instances' do
       expect(current_path).to eq("/automated_report/#{instance.identifier}")
       expect(page).to have_css("#output #{prefix}.#{template}")
       # For reports that depend on session source, check the right one was used.
-      if defined? source_name
-        expect(page).to have_content("(#{source_name})")
-      end
+      expect(page).to have_content("(#{source_name})") if defined? source_name
     end
   end
 

--- a/spec/features/automated_reports_spec.rb
+++ b/spec/features/automated_reports_spec.rb
@@ -108,16 +108,16 @@ RSpec.feature 'automated report' do
   end
 
   context 'session source is DS' do
-      given(:data_source) { 'DS' }
-      given(:data_source_name) { 'Discovery Service' }
+    given(:data_source) { 'DS' }
+    given(:data_source_name) { 'Discovery Service' }
 
-      it_behaves_like 'automated reports tests'
+    it_behaves_like 'automated reports tests'
   end
 
   context 'session source is IdP' do
-      given(:data_source) { 'IdP' }
-      given(:data_source_name) { 'IdP Event Log' }
+    given(:data_source) { 'IdP' }
+    given(:data_source_name) { 'IdP Event Log' }
 
-      it_behaves_like 'automated reports tests'
+    it_behaves_like 'automated reports tests'
   end
 end

--- a/spec/features/automated_reports_spec.rb
+++ b/spec/features/automated_reports_spec.rb
@@ -11,6 +11,7 @@ RSpec.feature 'automated report' do
   given!(:auto_report_idp) do
     create :automated_report,
            report_class: 'IdentityProviderSessionsReport',
+           source: 'DS',
            target: idp.entity_id
   end
 

--- a/spec/features/automated_reports_spec.rb
+++ b/spec/features/automated_reports_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature 'automated report' do
   given!(:auto_report_idp) do
     create :automated_report,
            report_class: 'IdentityProviderSessionsReport',
-           source: 'DS',
+           source: data_source,
            target: idp.entity_id
   end
 
@@ -45,62 +45,79 @@ RSpec.feature 'automated report' do
            subject: user
   end
 
-  describe 'when user has subscriptions' do
-    background do
-      attrs = create(:aaf_attributes, :from_subject, subject: user)
-      RapidRack::TestAuthenticator.jwt = create(:jwt, aaf_attributes: attrs)
+  shared_examples 'automated reports tests' do
+    describe 'when user has subscriptions' do
+      background do
+        attrs = create(:aaf_attributes, :from_subject, subject: user)
+        RapidRack::TestAuthenticator.jwt = create(:jwt, aaf_attributes: attrs)
 
-      stub_ide(shared_token: user.shared_token)
+        stub_ide(shared_token: user.shared_token)
 
-      visit '/auth/login'
-      click_button 'Login'
-      visit '/subscriber_reports'
-      click_link 'Subscriptions'
-    end
-
-    scenario 'viewing automated_reports#index' do
-      expect(current_path).to eq('/automated_reports')
-
-      expect(page).to have_text(idp.name[0..50])
-      expect(page).to have_text('Organizations')
-      expect(page).to have_text(saml.name[0..50])
-    end
-
-    scenario 'should unsubscribe and redirect to index' do
-      within 'table' do
-        first('button', text: 'Unsubscribe').click
-        click_link('Confirm Unsubscribe')
+        visit '/auth/login'
+        click_button 'Login'
+        visit '/subscriber_reports'
+        click_link 'Subscriptions'
       end
 
-      expect(current_path).to eq('/automated_reports')
+      scenario 'viewing automated_reports#index' do
+        expect(current_path).to eq('/automated_reports')
 
-      message = 'You have unsubscribed from an automated report'
+        expect(page).to have_text(idp.name[0..50])
+        expect(page).to have_text('Organizations')
+        expect(page).to have_text(saml.name[0..50])
+        expect(page).to have_text(data_source_name)
+      end
 
-      expect(page).to have_selector('p', text: message)
+      scenario 'should unsubscribe and redirect to index' do
+        within 'table' do
+          first('button', text: 'Unsubscribe').click
+          click_link('Confirm Unsubscribe')
+        end
+
+        expect(current_path).to eq('/automated_reports')
+
+        message = 'You have unsubscribed from an automated report'
+
+        expect(page).to have_selector('p', text: message)
+      end
+    end
+
+    describe 'when user has no subscriptions yet' do
+      background do
+        attrs = create(:aaf_attributes, :from_subject, subject: user_02)
+        RapidRack::TestAuthenticator.jwt = create(:jwt, aaf_attributes: attrs)
+
+        stub_ide(shared_token: user_02.shared_token)
+
+        visit '/auth/login'
+        click_button 'Login'
+        visit '/subscriber_reports'
+        click_link 'Subscriptions'
+      end
+
+      scenario 'should unsubscribe and redirect to index' do
+        expect(current_path).to eq('/automated_reports')
+
+        message = 'You can subscribe to an automated report by '\
+                  'clicking on the `Subscribe` button in report page '\
+                  'and choosing a report interval'
+
+        expect(page).to have_selector('p', text: message)
+      end
     end
   end
 
-  describe 'when user has no subscriptions yet' do
-    background do
-      attrs = create(:aaf_attributes, :from_subject, subject: user_02)
-      RapidRack::TestAuthenticator.jwt = create(:jwt, aaf_attributes: attrs)
+  context 'session source is DS' do
+      given(:data_source) { 'DS' }
+      given(:data_source_name) { 'Discovery Service' }
 
-      stub_ide(shared_token: user_02.shared_token)
+      it_behaves_like 'automated reports tests'
+  end
 
-      visit '/auth/login'
-      click_button 'Login'
-      visit '/subscriber_reports'
-      click_link 'Subscriptions'
-    end
+  context 'session source is IdP' do
+      given(:data_source) { 'IdP' }
+      given(:data_source_name) { 'IdP Event Log' }
 
-    scenario 'should unsubscribe and redirect to index' do
-      expect(current_path).to eq('/automated_reports')
-
-      message = 'You can subscribe to an automated report by '\
-                'clicking on the `Subscribe` button in report page '\
-                'and choosing a report interval'
-
-      expect(page).to have_selector('p', text: message)
-    end
+      it_behaves_like 'automated reports tests'
   end
 end

--- a/spec/features/compliance_reports_spec.rb
+++ b/spec/features/compliance_reports_spec.rb
@@ -57,6 +57,7 @@ RSpec.feature 'Compliance Reports' do
   context 'Identity Provider Attributes Report' do
     given(:button) { 'Identity Provider Attributes Report' }
     given(:report_class) { 'IdentityProviderAttributesReport' }
+    given(:source) { nil }
     given(:path) { 'identity_provider_attributes_report' }
     given(:template) { 'svg.identity-provider-attributes' }
 
@@ -69,6 +70,7 @@ RSpec.feature 'Compliance Reports' do
     given(:list) { 'Attributes' }
     given(:button) { 'Single Attribute Report – Service Providers' }
     given(:report_class) { 'RequestedAttributeReport' }
+    given(:source) { nil }
     given(:path) { 'attribute_service_providers_report' }
 
     it_behaves_like 'Subscribing to an automated report with target'
@@ -80,6 +82,7 @@ RSpec.feature 'Compliance Reports' do
     given(:list) { 'Attributes' }
     given(:button) { 'Single Attribute Report – Identity Providers' }
     given(:report_class) { 'ProvidedAttributeReport' }
+    given(:source) { nil }
     given(:path) { 'attribute_identity_providers_report' }
 
     it_behaves_like 'Subscribing to an automated report with target'
@@ -91,6 +94,7 @@ RSpec.feature 'Compliance Reports' do
     given(:list) { 'Service Provider' }
     given(:button) { 'Service Compatibility Report' }
     given(:report_class) { 'ServiceCompatibilityReport' }
+    given(:source) { nil }
     given(:path) { 'service_provider_compatibility_report' }
 
     it_behaves_like 'Subscribing to an automated report with target'

--- a/spec/features/federation_reports_spec.rb
+++ b/spec/features/federation_reports_spec.rb
@@ -24,6 +24,7 @@ RSpec.feature 'Federation Reports' do
     given(:button) { 'Federation Growth Report' }
     given(:path) { 'federation_growth_report' }
     given(:report_class) { 'FederationGrowthReport' }
+    given(:source) { nil }
     given(:template) { 'svg.federation-growth' }
 
     it_behaves_like 'Subscribing to a nil class report'
@@ -32,6 +33,7 @@ RSpec.feature 'Federation Reports' do
   context 'Federated Sessions Report' do
     given(:button) { 'Federated Sessions Report' }
     given(:report_class) { 'FederatedSessionsReport' }
+    given(:source) { 'DS' }
     given(:path) { 'federated_sessions_report' }
     given(:template) { 'svg.federated-sessions' }
 
@@ -41,6 +43,7 @@ RSpec.feature 'Federation Reports' do
   context 'Daily Demand Report' do
     given(:button) { 'Daily Demand Report' }
     given(:report_class) { 'DailyDemandReport' }
+    given(:source) { 'DS' }
     given(:path) { 'daily_demand_report' }
     given(:template) { 'svg.daily-demand' }
 

--- a/spec/features/identity_provider_reports_spec.rb
+++ b/spec/features/identity_provider_reports_spec.rb
@@ -25,56 +25,81 @@ RSpec.feature 'Identity Provider Reports' do
       visit '/subscriber_reports'
     end
 
-    scenario 'viewing the IdP Sessions Report' do
-      click_link('Identity Provider Sessions Report')
+    shared_examples 'viewing reports depending on session source' do
+      scenario 'viewing the IdP Sessions Report' do
+        click_link('Identity Provider Sessions Report')
 
-      expect(current_path)
-        .to eq('/subscriber_reports/identity_provider_sessions_report')
+        expect(current_path)
+          .to eq('/subscriber_reports/identity_provider_sessions_report')
 
-      select idp.name, from: 'Identity Providers'
-      fill_in 'start', with: 1.year.ago
-      fill_in 'end', with: Time.zone.now
+        select idp.name, from: 'Identity Providers'
+        fill_in 'start', with: 1.year.ago
+        fill_in 'end', with: Time.zone.now
+        select data_source_name, from: 'source'
 
-      click_button 'Generate'
+        click_button 'Generate'
 
-      expect(current_path)
-        .to eq('/subscriber_reports/identity_provider_sessions_report')
-      expect(page).to have_css('svg.identity-provider-sessions')
+        expect(current_path)
+          .to eq('/subscriber_reports/identity_provider_sessions_report')
+        expect(page).to have_css('svg.identity-provider-sessions')
+        expect(page).to have_content("(#{data_source_name})")
+      end
+
+      scenario 'viewing the IdP Daily Demand Report' do
+        click_link('Identity Provider Daily Demand Report')
+
+        expect(current_path)
+          .to eq('/subscriber_reports/identity_provider_daily_demand_report')
+
+        select idp.name, from: 'Identity Providers'
+        fill_in 'start', with: 1.year.ago
+        fill_in 'end', with: Time.zone.now
+        select data_source_name, from: 'source'
+
+        click_button 'Generate'
+
+        expect(current_path).to eq('/subscriber_reports/identity_provider_'\
+                                   'daily_demand_report')
+        expect(page).to have_css('svg.identity-provider-daily-demand')
+        expect(page).to have_content("(#{data_source_name})")
+      end
+
+      scenario 'viewing the Destination Services Report' do
+        click_link('Identity Provider Destination Services Report')
+
+        expect(current_path)
+          .to eq('/subscriber_reports/identity_provider_'\
+                 'destination_services_report')
+
+        select idp.name, from: 'Identity Providers'
+        fill_in 'start', with: 1.year.ago
+        fill_in 'end', with: Time.zone.now
+        select data_source_name, from: 'source'
+
+        click_button 'Generate'
+
+        expect(current_path)
+          .to eq('/subscriber_reports/identity_provider_'\
+                 'destination_services_report')
+        # Tabular reports do not render report title - see #178
+        # So instead just confirm the report-data JSON contains the title.
+        report_data = page.evaluate_script(
+          'document.getElementsByClassName("report-data")[0].innerHTML'
+        )
+        expect(report_data).to have_text("(#{data_source_name})")
+      end
     end
 
-    scenario 'viewing the IdP Daily Demand Report' do
-      click_link('Identity Provider Daily Demand Report')
+    context 'selecting DS session data source' do
+      let(:data_source_name) { 'Discovery Service' }
 
-      expect(current_path)
-        .to eq('/subscriber_reports/identity_provider_daily_demand_report')
-
-      select idp.name, from: 'Identity Providers'
-      fill_in 'start', with: 1.year.ago
-      fill_in 'end', with: Time.zone.now
-
-      click_button 'Generate'
-
-      expect(current_path).to eq('/subscriber_reports/identity_provider_'\
-                                 'daily_demand_report')
-      expect(page).to have_css('svg.identity-provider-daily-demand')
+      it_behaves_like 'viewing reports depending on session source'
     end
 
-    scenario 'viewing the Destination Services Report' do
-      click_link('Identity Provider Destination Services Report')
+    context 'selecting IdP session data source' do
+      let(:data_source_name) { 'IdP Event Log' }
 
-      expect(current_path)
-        .to eq('/subscriber_reports/identity_provider_'\
-               'destination_services_report')
-
-      select idp.name, from: 'Identity Providers'
-      fill_in 'start', with: 1.year.ago
-      fill_in 'end', with: Time.zone.now
-
-      click_button 'Generate'
-
-      expect(current_path)
-        .to eq('/subscriber_reports/identity_provider_'\
-               'destination_services_report')
+      it_behaves_like 'viewing reports depending on session source'
     end
   end
 

--- a/spec/features/service_provider_reports_spec.rb
+++ b/spec/features/service_provider_reports_spec.rb
@@ -25,56 +25,81 @@ RSpec.feature 'Service Provider Reports' do
       visit '/subscriber_reports'
     end
 
-    scenario 'viewing the SP Sessions Report' do
-      click_link('Service Provider Sessions Report')
+    shared_examples 'viewing reports depending on session source' do
+      scenario 'viewing the SP Sessions Report' do
+        click_link('Service Provider Sessions Report')
 
-      expect(current_path)
-        .to eq('/subscriber_reports/service_provider_sessions_report')
+        expect(current_path)
+          .to eq('/subscriber_reports/service_provider_sessions_report')
 
-      select sp.name, from: 'Service Providers'
-      fill_in 'start', with: 1.year.ago
-      fill_in 'end', with: Time.zone.now
+        select sp.name, from: 'Service Providers'
+        fill_in 'start', with: 1.year.ago
+        fill_in 'end', with: Time.zone.now
+        select data_source_name, from: 'source'
 
-      click_button 'Generate'
+        click_button 'Generate'
 
-      expect(current_path)
-        .to eq('/subscriber_reports/service_provider_sessions_report')
-      expect(page).to have_css('svg.service-provider-sessions')
+        expect(current_path)
+          .to eq('/subscriber_reports/service_provider_sessions_report')
+        expect(page).to have_css('svg.service-provider-sessions')
+        expect(page).to have_content("(#{data_source_name})")
+      end
+
+      scenario 'viewing the SP Daily Demand Report' do
+        click_link('Service Provider Daily Demand Report')
+
+        expect(current_path)
+          .to eq('/subscriber_reports/service_provider_daily_demand_report')
+
+        select sp.name, from: 'Service Providers'
+        fill_in 'start', with: 1.year.ago
+        fill_in 'end', with: Time.zone.now
+        select data_source_name, from: 'source'
+
+        click_button 'Generate'
+
+        expect(current_path).to eq('/subscriber_reports/service_provider_'\
+                                   'daily_demand_report')
+        expect(page).to have_css('svg.service-provider-daily-demand')
+        expect(page).to have_content("(#{data_source_name})")
+      end
+
+      scenario 'viewing the SP Source Identity Providers Report' do
+        click_link('Service Provider Source Identity Providers Report')
+
+        expect(current_path)
+          .to eq('/subscriber_reports/service_provider_'\
+                 'source_identity_providers_report')
+
+        select sp.name, from: 'Service Providers'
+        fill_in 'start', with: 1.year.ago.utc
+        fill_in 'end', with: Time.now.utc
+        select data_source_name, from: 'source'
+
+        click_button 'Generate'
+
+        expect(current_path)
+          .to eq('/subscriber_reports/service_provider_'\
+                 'source_identity_providers_report')
+        # Tabular reports do not render report title - see #178
+        # So instead just confirm the report-data JSON contains the title.
+        report_data = page.evaluate_script(
+          'document.getElementsByClassName("report-data")[0].innerHTML'
+        )
+        expect(report_data).to have_text("(#{data_source_name})")
+      end
     end
 
-    scenario 'viewing the SP Daily Demand Report' do
-      click_link('Service Provider Daily Demand Report')
+    context 'selecting DS session data source' do
+      let(:data_source_name) { 'Discovery Service' }
 
-      expect(current_path)
-        .to eq('/subscriber_reports/service_provider_daily_demand_report')
-
-      select sp.name, from: 'Service Providers'
-      fill_in 'start', with: 1.year.ago
-      fill_in 'end', with: Time.zone.now
-
-      click_button 'Generate'
-
-      expect(current_path).to eq('/subscriber_reports/service_provider_'\
-                                 'daily_demand_report')
-      expect(page).to have_css('svg.service-provider-daily-demand')
+      it_behaves_like 'viewing reports depending on session source'
     end
 
-    scenario 'viewing the SP Source Identity Providers Report' do
-      click_link('Service Provider Source Identity Providers Report')
+    context 'selecting IdP session data source' do
+      let(:data_source_name) { 'IdP Event Log' }
 
-      expect(current_path)
-        .to eq('/subscriber_reports/service_provider_'\
-               'source_identity_providers_report')
-
-      select sp.name, from: 'Service Providers'
-      fill_in 'start', with: 1.year.ago.utc
-      fill_in 'end', with: Time.now.utc
-
-      click_button 'Generate'
-
-      expect(current_path)
-        .to eq('/subscriber_reports/service_provider_'\
-               'source_identity_providers_report')
+      it_behaves_like 'viewing reports depending on session source'
     end
   end
 

--- a/spec/jobs/create_automated_report_instances_spec.rb
+++ b/spec/jobs/create_automated_report_instances_spec.rb
@@ -22,13 +22,15 @@ RSpec.describe CreateAutomatedReportInstances do
     let!("auto_report_#{i}_01".to_sym) do
       create :automated_report,
              interval: i,
-             report_class: 'DailyDemandReport'
+             report_class: 'DailyDemandReport',
+             source: 'DS'
     end
 
     let!("auto_report_#{i}_02".to_sym) do
       create :automated_report,
              interval: i,
              report_class: 'IdentityProviderDailyDemandReport',
+             source: 'DS',
              target: idp.entity_id
     end
   end

--- a/spec/models/automated_report_instance_spec.rb
+++ b/spec/models/automated_report_instance_spec.rb
@@ -38,7 +38,8 @@ RSpec.describe AutomatedReportInstance, type: :model do
 
     let(:automated_report) do
       create(:automated_report,
-             report_class: report_class, target: target, interval: interval)
+             report_class: report_class, source: source,
+             target: target, interval: interval)
     end
 
     subject do
@@ -107,29 +108,34 @@ RSpec.describe AutomatedReportInstance, type: :model do
                     range: true do
       let(:target_name) { 'Federation' }
       let(:report_class) { 'FederationGrowthReport' }
+      let(:source) { nil }
     end
 
     it_behaves_like 'an instantiated report', 'daily-demand',
                     range: true do
       let(:target_name) { 'Federation' }
       let(:report_class) { 'DailyDemandReport' }
+      let(:source) { 'DS' }
     end
 
     it_behaves_like 'an instantiated report', 'federated-sessions',
                     range: true do
       let(:target_name) { 'Federation' }
       let(:report_class) { 'FederatedSessionsReport' }
+      let(:source) { 'DS' }
     end
 
     it_behaves_like 'an instantiated report', 'subscriber-registrations' do
       let(:target) { 'organizations' }
       let(:target_name) { 'Organizations' }
       let(:report_class) { 'SubscriberRegistrationsReport' }
+      let(:source) { nil }
     end
 
     it_behaves_like 'an instantiated report', 'identity-provider-attributes' do
       let(:target_name) { 'Federation' }
       let(:report_class) { 'IdentityProviderAttributesReport' }
+      let(:source) { nil }
     end
 
     it_behaves_like 'an instantiated report',
@@ -138,6 +144,7 @@ RSpec.describe AutomatedReportInstance, type: :model do
       let(:target) { instance_target.entity_id }
       let(:target_name) { instance_target.name }
       let(:report_class) { 'IdentityProviderDailyDemandReport' }
+      let(:source) { 'DS' }
     end
 
     it_behaves_like 'an instantiated report',
@@ -146,6 +153,7 @@ RSpec.describe AutomatedReportInstance, type: :model do
       let(:target) { instance_target.entity_id }
       let(:target_name) { instance_target.name }
       let(:report_class) { 'IdentityProviderDestinationServicesReport' }
+      let(:source) { 'DS' }
     end
 
     it_behaves_like 'an instantiated report', 'identity-provider-sessions',
@@ -154,6 +162,7 @@ RSpec.describe AutomatedReportInstance, type: :model do
       let(:target) { instance_target.entity_id }
       let(:target_name) { instance_target.name }
       let(:report_class) { 'IdentityProviderSessionsReport' }
+      let(:source) { 'DS' }
     end
 
     it_behaves_like 'an instantiated report', 'provided-attribute' do
@@ -161,6 +170,7 @@ RSpec.describe AutomatedReportInstance, type: :model do
       let(:target) { instance_target.name }
       let(:target_name) { instance_target.name }
       let(:report_class) { 'ProvidedAttributeReport' }
+      let(:source) { nil }
     end
 
     it_behaves_like 'an instantiated report', 'requested-attribute' do
@@ -168,6 +178,7 @@ RSpec.describe AutomatedReportInstance, type: :model do
       let(:target) { instance_target.name }
       let(:target_name) { instance_target.name }
       let(:report_class) { 'RequestedAttributeReport' }
+      let(:source) { nil }
     end
 
     it_behaves_like 'an instantiated report', 'service-compatibility' do
@@ -175,6 +186,7 @@ RSpec.describe AutomatedReportInstance, type: :model do
       let(:target) { instance_target.entity_id }
       let(:target_name) { instance_target.name }
       let(:report_class) { 'ServiceCompatibilityReport' }
+      let(:source) { nil }
     end
 
     it_behaves_like 'an instantiated report', 'service-provider-daily-demand',
@@ -183,6 +195,7 @@ RSpec.describe AutomatedReportInstance, type: :model do
       let(:target) { instance_target.entity_id }
       let(:target_name) { instance_target.name }
       let(:report_class) { 'ServiceProviderDailyDemandReport' }
+      let(:source) { 'DS' }
     end
 
     it_behaves_like 'an instantiated report', 'service-provider-sessions',
@@ -191,6 +204,7 @@ RSpec.describe AutomatedReportInstance, type: :model do
       let(:target) { instance_target.entity_id }
       let(:target_name) { instance_target.name }
       let(:report_class) { 'ServiceProviderSessionsReport' }
+      let(:source) { 'DS' }
     end
 
     it_behaves_like 'an instantiated report',
@@ -199,18 +213,21 @@ RSpec.describe AutomatedReportInstance, type: :model do
       let(:target) { instance_target.entity_id }
       let(:target_name) { instance_target.name }
       let(:report_class) { 'ServiceProviderSourceIdentityProvidersReport' }
+      let(:source) { 'DS' }
     end
 
     it_behaves_like 'an instantiated report',
                     'identity-provider-utilization' do
       let(:target_name) { 'Identity Providers' }
       let(:report_class) { 'IdentityProviderUtilizationReport' }
+      let(:source) { 'DS' }
     end
 
     it_behaves_like 'an instantiated report',
                     'service-provider-utilization' do
       let(:target_name) { 'Service Providers' }
       let(:report_class) { 'ServiceProviderUtilizationReport' }
+      let(:source) { 'DS' }
     end
   end
 end

--- a/spec/models/automated_report_spec.rb
+++ b/spec/models/automated_report_spec.rb
@@ -121,4 +121,17 @@ RSpec.describe AutomatedReport, type: :model do
       expect(subject.interval).to be_nil
     end
   end
+
+  before do
+    allow(Rails.application.config)
+      .to receive_message_chain(:reporting_service, :default_session_source)
+      .and_return(nil)
+  end
+
+  describe '#source_if_needed' do
+    it 'returns a valid source' do
+      subject.report_class = :DailyDemandReport
+      expect(subject.source_if_needed).not_to be_nil
+    end
+  end
 end

--- a/spec/models/automated_report_spec.rb
+++ b/spec/models/automated_report_spec.rb
@@ -80,6 +80,25 @@ RSpec.describe AutomatedReport, type: :model do
       end
     end
 
+    it 'requires a source for reports that need it' do
+      reports_that_need_source = %w[
+        DailyDemandReport FederatedSessionsReport
+        IdentityProviderDailyDemandReport
+        IdentityProviderDestinationServicesReport IdentityProviderSessionsReport
+        ServiceProviderDailyDemandReport ServiceProviderSessionsReport
+        ServiceProviderSourceIdentityProvidersReport
+        IdentityProviderUtilizationReport ServiceProviderUtilizationReport
+      ]
+      reports_that_need_source.each do |klass|
+        subject.report_class = klass
+        expect(subject).to allow_value('DS').for(:source)
+        expect(subject).to allow_value('IdP').for(:source)
+        expect(subject).not_to allow_value(nil).for(:source)
+        expect(subject).not_to allow_value('').for(:source)
+        expect(subject).not_to allow_value('CrystalBall').for(:source)
+      end
+    end
+
     it 'requires an attribute name for attribute reports' do
       %w[ProvidedAttributeReport RequestedAttributeReport].each do |klass|
         subject.report_class = klass

--- a/spec/reports/daily_demand_report_spec.rb
+++ b/spec/reports/daily_demand_report_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe DailyDemandReport do
   let(:identity_provider) { create :identity_provider }
   let(:service_provider) { create :service_provider }
 
-  subject { DailyDemandReport.new(start, finish) }
+  subject { DailyDemandReport.new(start, finish, 'DS') }
 
   let(:report) { subject.generate }
   let(:data) { report[:data] }

--- a/spec/reports/daily_demand_report_spec.rb
+++ b/spec/reports/daily_demand_report_spec.rb
@@ -44,7 +44,8 @@ RSpec.describe DailyDemandReport do
     let(:value) { anything }
 
     it 'should include title, units and labels' do
-      expect(report).to include(title: title, units: units,
+      output_title = title + ' (Discovery Service)'
+      expect(report).to include(title: output_title, units: units,
                                 labels: labels, range: range)
     end
 

--- a/spec/reports/federated_sessions_report_spec.rb
+++ b/spec/reports/federated_sessions_report_spec.rb
@@ -48,7 +48,8 @@ RSpec.describe FederatedSessionsReport do
     let(:value) { anything }
 
     it 'should include title, units, labels and range' do
-      expect(report).to include(title: title, units: units,
+      output_title = title + ' (Discovery Service)'
+      expect(report).to include(title: output_title, units: units,
                                 labels: labels, range: range)
     end
 

--- a/spec/reports/federated_sessions_report_spec.rb
+++ b/spec/reports/federated_sessions_report_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe FederatedSessionsReport do
   let(:identity_provider) { create :identity_provider }
   let(:service_provider) { create :service_provider }
 
-  subject { FederatedSessionsReport.new(start, finish, steps, 'DS') }
+  subject { FederatedSessionsReport.new(start, finish, steps, source) }
 
   let(:report) { subject.generate }
   let(:data) { report[:data] }
@@ -38,17 +38,12 @@ RSpec.describe FederatedSessionsReport do
     end
   end
 
-  context 'when events are sessions with response' do
-    before do
-      create_list :discovery_service_event, 20, :response,
-                  selected_idp: identity_provider.entity_id,
-                  initiating_sp: service_provider.entity_id
-    end
-
+  shared_examples 'a report procesing events from the selected source' do
+    before { 20.times { create_event } }
     let(:value) { anything }
 
     it 'should include title, units, labels and range' do
-      output_title = title + ' (Discovery Service)'
+      output_title = title + ' (' + source_name + ')'
       expect(report).to include(title: output_title, units: units,
                                 labels: labels, range: range)
     end
@@ -66,28 +61,33 @@ RSpec.describe FederatedSessionsReport do
     end
 
     let(:value) { 0.0 }
+    let(:source) { 'DS' }
 
     it 'should not count any sessions' do
       expect_in_range
     end
   end
 
-  context 'when events timestamps are specified manually' do
+  context 'when IdP events are failed' do
+    before do
+      create_list :federated_login_event, 20,
+                  relying_party: service_provider.entity_id,
+                  timestamp: 1.day.ago.beginning_of_day
+    end
+
+    let(:value) { 0.0 }
+    let(:source) { 'IdP' }
+
+    it 'should not count any sessions' do
+      expect_in_range
+    end
+  end
+
+  shared_examples 'when events timestamps are specified manually' do
     before :example do
-      create_list :discovery_service_event, 5, :response,
-                  selected_idp: identity_provider.entity_id,
-                  initiating_sp: service_provider.entity_id,
-                  timestamp: start
-
-      create_list :discovery_service_event, 10, :response,
-                  selected_idp: identity_provider.entity_id,
-                  initiating_sp: service_provider.entity_id,
-                  timestamp: 2.days.ago.beginning_of_day
-
-      create_list :discovery_service_event, 9, :response,
-                  selected_idp: identity_provider.entity_id,
-                  initiating_sp: service_provider.entity_id,
-                  timestamp: finish
+      5.times { create_event(start) }
+      10.times { create_event(2.days.ago.beginning_of_day) }
+      9.times { create_event(finish) }
     end
 
     it 'average should be 1.0 for 5 sessions during first 5 hours' do
@@ -108,5 +108,35 @@ RSpec.describe FederatedSessionsReport do
       time = [*scope_range].last
       expect(data[:sessions]).to include([time, 1.8])
     end
+  end
+
+  context 'when events are sessions with response' do
+    def create_event(timestamp = nil)
+      create :discovery_service_event, :response,
+             { selected_idp: identity_provider.entity_id,
+               initiating_sp: service_provider.entity_id,
+               timestamp: timestamp }.compact
+    end
+
+    let(:source) { 'DS' }
+    let(:source_name) { 'Discovery Service' }
+
+    it_behaves_like 'a report procesing events from the selected source'
+    it_behaves_like 'when events timestamps are specified manually'
+  end
+
+  context 'when events are IdP sessions' do
+    def create_event(timestamp = nil)
+      create :federated_login_event, :OK,
+             { asserting_party: identity_provider.entity_id,
+               relying_party: service_provider.entity_id,
+               timestamp: timestamp }.compact
+    end
+
+    let(:source) { 'IdP' }
+    let(:source_name) { 'IdP Event Log' }
+
+    it_behaves_like 'a report procesing events from the selected source'
+    it_behaves_like 'when events timestamps are specified manually'
   end
 end

--- a/spec/reports/federated_sessions_report_spec.rb
+++ b/spec/reports/federated_sessions_report_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe FederatedSessionsReport do
   let(:identity_provider) { create :identity_provider }
   let(:service_provider) { create :service_provider }
 
-  subject { FederatedSessionsReport.new(start, finish, steps) }
+  subject { FederatedSessionsReport.new(start, finish, steps, 'DS') }
 
   let(:report) { subject.generate }
   let(:data) { report[:data] }

--- a/spec/reports/identity_provider_daily_demand_report_spec.rb
+++ b/spec/reports/identity_provider_daily_demand_report_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe IdentityProviderDailyDemandReport do
 
   subject do
     IdentityProviderDailyDemandReport
-      .new(identity_provider_01.entity_id, start, finish, 'DS')
+      .new(identity_provider_01.entity_id, start, finish, source)
   end
 
   let(:report) { subject.generate }
@@ -36,18 +36,18 @@ RSpec.describe IdentityProviderDailyDemandReport do
     end
   end
 
-  context 'sessions with response' do
+  shared_examples 'a report procesing events from the selected source' do
     before do
-      create_list :discovery_service_event, 5, :response,
-                  selected_idp: identity_provider_01.entity_id,
-                  initiating_sp: service_provider.entity_id
+      5.times do
+        create_event(identity_provider_01.entity_id, service_provider.entity_id)
+      end
     end
 
     let(:value) { anything }
 
     it 'should include title, units and labels' do
       output_title = title + ' ' + identity_provider_01.name +
-                     ' (Discovery Service)'
+                     ' (' + source_name + ')'
       expect(report).to include(title: output_title,
                                 units: units, labels: labels, range: range)
     end
@@ -65,34 +65,46 @@ RSpec.describe IdentityProviderDailyDemandReport do
     end
 
     let(:value) { 0.00 }
+    let(:source) { 'DS' }
 
     it 'should not count any sessions' do
       expect_in_range
     end
   end
 
-  context 'events at different times manually' do
+  context 'when failed event' do
+    before do
+      create_list :federated_login_event, 10,
+                  relying_party: service_provider.entity_id,
+                  timestamp: 1.day.ago.beginning_of_day
+    end
+
+    let(:value) { 0.00 }
+    let(:source) { 'IdP' }
+
+    it 'should not count any sessions' do
+      expect_in_range
+    end
+  end
+
+  shared_examples 'events at different times manually' do
     before :example do
       [*1..5].each do |n|
-        create :discovery_service_event, :response,
-               selected_idp: identity_provider_01.entity_id,
-               initiating_sp: service_provider.entity_id,
-               timestamp: n.days.ago.beginning_of_day
+        create_event(identity_provider_01.entity_id,
+                     service_provider.entity_id,
+                     n.days.ago.beginning_of_day)
 
-        create :discovery_service_event, :response,
-               selected_idp: identity_provider_01.entity_id,
-               initiating_sp: service_provider.entity_id,
-               timestamp: n.days.ago.beginning_of_day + 10.minutes
+        create_event(identity_provider_01.entity_id,
+                     service_provider.entity_id,
+                     n.days.ago.beginning_of_day + 10.minutes)
 
-        create :discovery_service_event, :response,
-               selected_idp: identity_provider_01.entity_id,
-               initiating_sp: service_provider.entity_id,
-               timestamp: n.days.ago.end_of_day
+        create_event(identity_provider_01.entity_id,
+                     service_provider.entity_id,
+                     n.days.ago.end_of_day)
 
-        create :discovery_service_event, :response,
-               selected_idp: identity_provider_02.entity_id,
-               initiating_sp: service_provider.entity_id,
-               timestamp: n.days.ago.end_of_day
+        create_event(identity_provider_02.entity_id,
+                     service_provider.entity_id,
+                     n.days.ago.end_of_day)
       end
     end
 
@@ -111,5 +123,35 @@ RSpec.describe IdentityProviderDailyDemandReport do
     it 'should not include sessions for irrelevant IdP (average must be 0.5)' do
       expect(data[:sessions]).to include([86_100, 0.45])
     end
+  end
+
+  context 'sessions with response' do
+    def create_event(idp, sp, timestamp = nil)
+      create :discovery_service_event, :response,
+             { selected_idp: idp,
+               initiating_sp: sp,
+               timestamp: timestamp } .compact
+    end
+
+    let(:source) { 'DS' }
+    let(:source_name) { 'Discovery Service' }
+
+    it_behaves_like 'a report procesing events from the selected source'
+    it_behaves_like 'events at different times manually'
+  end
+
+  context 'IdP sessions' do
+    def create_event(idp, sp, timestamp = nil)
+      create :federated_login_event, :OK,
+             { asserting_party: idp,
+               relying_party: sp,
+               timestamp: timestamp } .compact
+    end
+
+    let(:source) { 'IdP' }
+    let(:source_name) { 'IdP Event Log' }
+
+    it_behaves_like 'a report procesing events from the selected source'
+    it_behaves_like 'events at different times manually'
   end
 end

--- a/spec/reports/identity_provider_daily_demand_report_spec.rb
+++ b/spec/reports/identity_provider_daily_demand_report_spec.rb
@@ -46,7 +46,8 @@ RSpec.describe IdentityProviderDailyDemandReport do
     let(:value) { anything }
 
     it 'should include title, units and labels' do
-      output_title = title + ' ' + identity_provider_01.name
+      output_title = title + ' ' + identity_provider_01.name +
+                     ' (Discovery Service)'
       expect(report).to include(title: output_title,
                                 units: units, labels: labels, range: range)
     end

--- a/spec/reports/identity_provider_daily_demand_report_spec.rb
+++ b/spec/reports/identity_provider_daily_demand_report_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe IdentityProviderDailyDemandReport do
 
   subject do
     IdentityProviderDailyDemandReport
-      .new(identity_provider_01.entity_id, start, finish)
+      .new(identity_provider_01.entity_id, start, finish, 'DS')
   end
 
   let(:report) { subject.generate }

--- a/spec/reports/identity_provider_destination_services_report_spec.rb
+++ b/spec/reports/identity_provider_destination_services_report_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe IdentityProviderDestinationServicesReport do
 
   context 'IdP Destination Report' do
     it 'output should include :type, :title, :header and :footer' do
-      output_title = "#{title} #{idp.name}"
+      output_title = "#{title} #{idp.name} (Discovery Service)"
       expect(report).to include(type: type,
                                 title: output_title, header: header)
     end

--- a/spec/reports/identity_provider_destination_services_report_spec.rb
+++ b/spec/reports/identity_provider_destination_services_report_spec.rb
@@ -21,40 +21,27 @@ RSpec.describe IdentityProviderDestinationServicesReport do
 
   subject do
     IdentityProviderDestinationServicesReport.new(idp.entity_id, start, finish,
-                                                  'DS')
+                                                  source)
   end
 
   let(:report) { subject.generate }
 
-  context 'IdP Destination Report' do
+  shared_examples 'IdP Destination Report' do
     it 'output should include :type, :title, :header and :footer' do
-      output_title = "#{title} #{idp.name} (Discovery Service)"
+      output_title = "#{title} #{idp.name} (#{source_name})"
       expect(report).to include(type: type,
                                 title: output_title, header: header)
     end
   end
 
-  context '#generate' do
+  shared_examples '#generate' do
     before do
-      create_list :discovery_service_event, 20, :response,
-                  selected_idp: idp.entity_id
-
-      create_list :discovery_service_event, 20, :response,
-                  selected_idp: idp.entity_id,
-                  initiating_sp: sp1.entity_id
-
-      create_list :discovery_service_event, 5, :response,
-                  selected_idp: idp.entity_id,
-                  initiating_sp: sp2.entity_id
-
-      create_list :discovery_service_event, 10,
-                  selected_idp: idp.entity_id,
-                  initiating_sp: sp3.entity_id,
-                  timestamp: 20.days.ago.beginning_of_day
-
-      create_list :discovery_service_event, 5, :response,
-                  selected_idp: idp2.entity_id,
-                  initiating_sp: sp4.entity_id
+      20.times { create_event(idp.entity_id) }
+      20.times { create_event(idp.entity_id, sp1.entity_id) }
+      5.times { create_event(idp.entity_id, sp2.entity_id) }
+      long_ago = 20.days.ago.beginning_of_day
+      10.times { create_event(idp.entity_id, sp3.entity_id, long_ago) }
+      5.times { create_event(idp2.entity_id, sp4.entity_id) }
     end
 
     it 'creates report :rows with number of related SPs and SP names
@@ -70,5 +57,35 @@ RSpec.describe IdentityProviderDestinationServicesReport do
     it 'report should not include sessions from irrelevant entities' do
       expect(report[:rows]).not_to include([sp4.name, anything])
     end
+  end
+
+  context 'when sessions are Discovery Service sessions' do
+    def create_event(idp_entity_id, sp_entity_id = nil, timestamp = nil)
+      create :discovery_service_event, :response,
+             { selected_idp: idp_entity_id,
+               initiating_sp: sp_entity_id,
+               timestamp: timestamp }.compact
+    end
+
+    let(:source) { 'DS' }
+    let(:source_name) { 'Discovery Service' }
+
+    it_behaves_like 'IdP Destination Report'
+    it_behaves_like '#generate'
+  end
+
+  context 'when events are IdP sessions' do
+    def create_event(idp_entity_id, sp_entity_id = nil, timestamp = nil)
+      create :federated_login_event, :OK,
+             { asserting_party: idp_entity_id,
+               relying_party: sp_entity_id,
+               timestamp: timestamp }.compact
+    end
+
+    let(:source) { 'IdP' }
+    let(:source_name) { 'IdP Event Log' }
+
+    it_behaves_like 'IdP Destination Report'
+    it_behaves_like '#generate'
   end
 end

--- a/spec/reports/identity_provider_destination_services_report_spec.rb
+++ b/spec/reports/identity_provider_destination_services_report_spec.rb
@@ -20,7 +20,8 @@ RSpec.describe IdentityProviderDestinationServicesReport do
   let(:sp4) { create :service_provider }
 
   subject do
-    IdentityProviderDestinationServicesReport.new(idp.entity_id, start, finish)
+    IdentityProviderDestinationServicesReport.new(idp.entity_id, start, finish,
+                                                  'DS')
   end
 
   let(:report) { subject.generate }

--- a/spec/reports/identity_provider_sessions_report_spec.rb
+++ b/spec/reports/identity_provider_sessions_report_spec.rb
@@ -30,7 +30,8 @@ RSpec.describe IdentityProviderSessionsReport do
   let(:sp) { create :service_provider }
 
   subject do
-    IdentityProviderSessionsReport.new(idp.entity_id, start, finish, steps)
+    IdentityProviderSessionsReport.new(idp.entity_id, start, finish, steps,
+                                       'DS')
   end
 
   let(:report) { subject.generate }

--- a/spec/reports/identity_provider_sessions_report_spec.rb
+++ b/spec/reports/identity_provider_sessions_report_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe IdentityProviderSessionsReport do
     let(:value) { anything }
 
     it 'should include title, units, labels and range' do
-      output_title = title + ' ' + idp.name
+      output_title = title + ' ' + idp.name + ' (Discovery Service)'
       expect(report).to include(title: output_title, units: units,
                                 labels: labels, range: range)
     end

--- a/spec/reports/identity_provider_utilization_report_spec.rb
+++ b/spec/reports/identity_provider_utilization_report_spec.rb
@@ -6,14 +6,38 @@ RSpec.describe IdentityProviderUtilizationReport do
   let(:type) { 'identity-provider-utilization' }
   let(:header) { [%w[Name Sessions]] }
   let(:title) { 'Identity Provider Utilization Report' }
-  let(:output_title) { title + ' (Discovery Service)' }
+  let(:output_title) { title + ' (' + source_name + ')' }
 
-  subject { IdentityProviderUtilizationReport.new(start, finish, 'DS') }
+  subject { IdentityProviderUtilizationReport.new(start, finish, source) }
 
-  context 'Identity Provider Utilization report #Generate' do
+  shared_examples 'Identity Provider Utilization report #Generate' do
     let(:object_type) { :identity_provider }
-    let(:target) { :selected_idp }
 
     it_behaves_like 'Utilization Report'
+  end
+
+  context 'IdentityProviderUtilizationReport with DS sessions' do
+    let(:target) { :selected_idp }
+    def create_event(timestamp, eid)
+      create :discovery_service_event, :response,
+             target => eid, timestamp: timestamp
+    end
+
+    let(:source) { 'DS' }
+    let(:source_name) { 'Discovery Service' }
+
+    it_behaves_like 'Identity Provider Utilization report #Generate'
+  end
+
+  context 'IdentityProviderUtilizationReport with IdP sessions' do
+    let(:target) { :asserting_party }
+    def create_event(timestamp, eid)
+      create :federated_login_event, :OK, target => eid, timestamp: timestamp
+    end
+
+    let(:source) { 'IdP' }
+    let(:source_name) { 'IdP Event Log' }
+
+    it_behaves_like 'Identity Provider Utilization report #Generate'
   end
 end

--- a/spec/reports/identity_provider_utilization_report_spec.rb
+++ b/spec/reports/identity_provider_utilization_report_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe IdentityProviderUtilizationReport do
   let(:type) { 'identity-provider-utilization' }
   let(:header) { [%w[Name Sessions]] }
   let(:title) { 'Identity Provider Utilization Report' }
+  let(:output_title) { title + ' (Discovery Service)' }
 
   subject { IdentityProviderUtilizationReport.new(start, finish, 'DS') }
 

--- a/spec/reports/identity_provider_utilization_report_spec.rb
+++ b/spec/reports/identity_provider_utilization_report_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe IdentityProviderUtilizationReport do
 
   subject { IdentityProviderUtilizationReport.new(start, finish, 'DS') }
 
-  context 'Service Provider Utilization report #Generate' do
+  context 'Identity Provider Utilization report #Generate' do
     let(:object_type) { :identity_provider }
     let(:target) { :selected_idp }
 

--- a/spec/reports/identity_provider_utilization_report_spec.rb
+++ b/spec/reports/identity_provider_utilization_report_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe IdentityProviderUtilizationReport do
   let(:header) { [%w[Name Sessions]] }
   let(:title) { 'Identity Provider Utilization Report' }
 
-  subject { IdentityProviderUtilizationReport.new(start, finish) }
+  subject { IdentityProviderUtilizationReport.new(start, finish, 'DS') }
 
   context 'Service Provider Utilization report #Generate' do
     let(:object_type) { :identity_provider }

--- a/spec/reports/service_provider_daily_demand_report_spec.rb
+++ b/spec/reports/service_provider_daily_demand_report_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe ServiceProviderDailyDemandReport do
 
   subject do
     ServiceProviderDailyDemandReport
-      .new(service_provider_01.entity_id, start, finish)
+      .new(service_provider_01.entity_id, start, finish, 'DS')
   end
 
   let(:report) { subject.generate }

--- a/spec/reports/service_provider_daily_demand_report_spec.rb
+++ b/spec/reports/service_provider_daily_demand_report_spec.rb
@@ -46,7 +46,8 @@ RSpec.describe ServiceProviderDailyDemandReport do
     let(:value) { anything }
 
     it 'should include title, units and labels' do
-      output_title = title + ' ' + service_provider_01.name
+      output_title = title + ' ' + service_provider_01.name +
+                     ' (Discovery Service)'
       expect(report).to include(title: output_title,
                                 units: units, labels: labels, range: range)
     end

--- a/spec/reports/service_provider_sessions_report_spec.rb
+++ b/spec/reports/service_provider_sessions_report_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe ServiceProviderSessionsReport do
     let(:value) { anything }
 
     it 'should include title, units, labels and range' do
-      output_title = title + ' ' + sp_01.name
+      output_title = title + ' ' + sp_01.name + ' (Discovery Service)'
       expect(report).to include(title: output_title, units: units,
                                 labels: labels, range: range)
     end

--- a/spec/reports/service_provider_sessions_report_spec.rb
+++ b/spec/reports/service_provider_sessions_report_spec.rb
@@ -30,7 +30,8 @@ RSpec.describe ServiceProviderSessionsReport do
   let(:sp_02) { create :service_provider }
 
   subject do
-    ServiceProviderSessionsReport.new(sp_01.entity_id, start, finish, steps)
+    ServiceProviderSessionsReport.new(sp_01.entity_id, start, finish, steps,
+                                      'DS')
   end
 
   let(:report) { subject.generate }

--- a/spec/reports/service_provider_sessions_report_spec.rb
+++ b/spec/reports/service_provider_sessions_report_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe ServiceProviderSessionsReport do
 
   subject do
     ServiceProviderSessionsReport.new(sp_01.entity_id, start, finish, steps,
-                                      'DS')
+                                      source)
   end
 
   let(:report) { subject.generate }
@@ -43,17 +43,17 @@ RSpec.describe ServiceProviderSessionsReport do
     end
   end
 
-  context 'sessions' do
+  shared_examples 'sessions' do
     before do
-      create_list :discovery_service_event, 20, :response,
-                  selected_idp: idp.entity_id,
-                  initiating_sp: sp_01.entity_id
+      20.times do
+        create_event(idp.entity_id, sp_01.entity_id)
+      end
     end
 
     let(:value) { anything }
 
     it 'should include title, units, labels and range' do
-      output_title = title + ' ' + sp_01.name + ' (Discovery Service)'
+      output_title = title + ' ' + sp_01.name + ' (' + source_name + ')'
       expect(report).to include(title: output_title, units: units,
                                 labels: labels, range: range)
     end
@@ -70,33 +70,33 @@ RSpec.describe ServiceProviderSessionsReport do
     end
 
     let(:value) { 0.0 }
+    let(:source) { 'DS' }
 
     it 'should not count SP sessions' do
       expect_in_range
     end
   end
 
-  context 'SPs with sessions' do
+  context 'when SP sessions are failed at IdP' do
+    before do
+      create_list :federated_login_event, 2,
+                  relying_party: sp_01.entity_id
+    end
+
+    let(:value) { 0.0 }
+    let(:source) { 'IdP' }
+
+    it 'should not count SP sessions' do
+      expect_in_range
+    end
+  end
+
+  shared_examples 'SPs with sessions' do
     before :example do
-      create_list :discovery_service_event, 5, :response,
-                  selected_idp: idp.entity_id,
-                  initiating_sp: sp_01.entity_id,
-                  timestamp: start
-
-      create_list :discovery_service_event, 10, :response,
-                  selected_idp: idp.entity_id,
-                  initiating_sp: sp_01.entity_id,
-                  timestamp: finish - 2.days
-
-      create_list :discovery_service_event, 9, :response,
-                  selected_idp: idp.entity_id,
-                  initiating_sp: sp_01.entity_id,
-                  timestamp: finish
-
-      create_list :discovery_service_event, 9, :response,
-                  selected_idp: idp.entity_id,
-                  initiating_sp: sp_02.entity_id,
-                  timestamp: finish
+      5.times { create_event(idp.entity_id, sp_01.entity_id, start) }
+      10.times { create_event(idp.entity_id, sp_01.entity_id, finish - 2.days) }
+      9.times { create_event(idp.entity_id, sp_01.entity_id, finish) }
+      9.times { create_event(idp.entity_id, sp_02.entity_id, finish) }
     end
 
     it 'average should be 1.0 for 5 SP sessions during first 5 hours' do
@@ -117,5 +117,35 @@ RSpec.describe ServiceProviderSessionsReport do
       time = [*scope_range].last
       expect(data[:sessions]).to include([time, 1.8])
     end
+  end
+
+  context 'when events are sessions with response' do
+    def create_event(idp, sp, timestamp = nil)
+      create :discovery_service_event, :response,
+             { selected_idp: idp,
+               initiating_sp: sp,
+               timestamp: timestamp }.compact
+    end
+
+    let(:source) { 'DS' }
+    let(:source_name) { 'Discovery Service' }
+
+    it_behaves_like 'sessions'
+    it_behaves_like 'SPs with sessions'
+  end
+
+  context 'when events are IdP sessions' do
+    def create_event(idp, sp, timestamp = nil)
+      create :federated_login_event, :OK,
+             { asserting_party: idp,
+               relying_party: sp,
+               timestamp: timestamp }.compact
+    end
+
+    let(:source) { 'IdP' }
+    let(:source_name) { 'IdP Event Log' }
+
+    it_behaves_like 'sessions'
+    it_behaves_like 'SPs with sessions'
   end
 end

--- a/spec/reports/service_provider_source_identity_providers_report_spec.rb
+++ b/spec/reports/service_provider_source_identity_providers_report_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe ServiceProviderSourceIdentityProvidersReport do
 
   subject do
     ServiceProviderSourceIdentityProvidersReport
-      .new(sp.entity_id, start, finish)
+      .new(sp.entity_id, start, finish, 'DS')
   end
 
   let(:report) { subject.generate }

--- a/spec/reports/service_provider_source_identity_providers_report_spec.rb
+++ b/spec/reports/service_provider_source_identity_providers_report_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe ServiceProviderSourceIdentityProvidersReport do
 
   context 'SP Source IdPs Report' do
     it 'output should include :type, :title, :header and :footer' do
-      output_title = "#{title} #{sp.name}"
+      output_title = "#{title} #{sp.name} (Discovery Service)"
       expect(report).to include(type: type,
                                 title: output_title, header: header)
     end

--- a/spec/reports/service_provider_utilization_report_spec.rb
+++ b/spec/reports/service_provider_utilization_report_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ServiceProviderUtilizationReport do
   let(:header) { [%w[Name Sessions]] }
   let(:title) { 'Service Provider Utilization Report' }
 
-  subject { ServiceProviderUtilizationReport.new(start, finish) }
+  subject { ServiceProviderUtilizationReport.new(start, finish, 'DS') }
 
   context 'Service Provider Utilization report #Generate' do
     let(:object_type) { :service_provider }

--- a/spec/reports/service_provider_utilization_report_spec.rb
+++ b/spec/reports/service_provider_utilization_report_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe ServiceProviderUtilizationReport do
   let(:type) { 'service-provider-utilization' }
   let(:header) { [%w[Name Sessions]] }
   let(:title) { 'Service Provider Utilization Report' }
+  let(:output_title) { title + ' (Discovery Service)' }
 
   subject { ServiceProviderUtilizationReport.new(start, finish, 'DS') }
 

--- a/spec/reports/service_provider_utilization_report_spec.rb
+++ b/spec/reports/service_provider_utilization_report_spec.rb
@@ -6,14 +6,38 @@ RSpec.describe ServiceProviderUtilizationReport do
   let(:type) { 'service-provider-utilization' }
   let(:header) { [%w[Name Sessions]] }
   let(:title) { 'Service Provider Utilization Report' }
-  let(:output_title) { title + ' (Discovery Service)' }
+  let(:output_title) { title + ' (' + source_name + ')' }
 
-  subject { ServiceProviderUtilizationReport.new(start, finish, 'DS') }
+  subject { ServiceProviderUtilizationReport.new(start, finish, source) }
 
-  context 'Service Provider Utilization report #Generate' do
+  shared_examples 'Service Provider Utilization report #Generate' do
     let(:object_type) { :service_provider }
-    let(:target) { :initiating_sp }
 
     it_behaves_like 'Utilization Report'
+  end
+
+  context 'ServiceProviderUtilizationReport with DS sessions' do
+    let(:target) { :initiating_sp }
+    def create_event(timestamp, eid)
+      create :discovery_service_event, :response,
+             target => eid, timestamp: timestamp
+    end
+
+    let(:source) { 'DS' }
+    let(:source_name) { 'Discovery Service' }
+
+    it_behaves_like 'Service Provider Utilization report #Generate'
+  end
+
+  context 'ServiceProviderUtilizationReport with IdP sessions' do
+    let(:target) { :relying_party }
+    def create_event(timestamp, eid)
+      create :federated_login_event, :OK, target => eid, timestamp: timestamp
+    end
+
+    let(:source) { 'IdP' }
+    let(:source_name) { 'IdP Event Log' }
+
+    it_behaves_like 'Service Provider Utilization report #Generate'
   end
 end

--- a/spec/support/subscriber_reports_controller.rb
+++ b/spec/support/subscriber_reports_controller.rb
@@ -21,7 +21,9 @@ RSpec.shared_examples 'a Subscriber Report' do
 
   def run_post
     post report_path, params: {
-      entity_id: object.entity_id, start: 1.year.ago.utc, end: Time.now.utc
+      entity_id: object.entity_id, start: 1.year.ago.utc, end: Time.now.utc,
+      source: 'DS'
+      # TODO: test also other sources
     }
   end
 
@@ -74,7 +76,7 @@ RSpec.shared_examples 'a Subscriber Report' do
   end
 
   context 'steps should scale correctly' do
-    let(:params) { { entity_id: object.entity_id } }
+    let(:params) { { entity_id: object.entity_id, source: 'DS' } }
     let(:path) { :sessions_report }
 
     it_behaves_like 'report with scalable steps'

--- a/spec/support/subscription_features.rb
+++ b/spec/support/subscription_features.rb
@@ -6,7 +6,8 @@ RSpec.shared_examples 'Subscribing to an automated report with target' do
       create :automated_report,
              interval: interval,
              target: target,
-             report_class: report_class
+             report_class: report_class,
+             source: source
     end
   end
 

--- a/spec/support/subscription_with_nil_target_features.rb
+++ b/spec/support/subscription_with_nil_target_features.rb
@@ -5,7 +5,8 @@ RSpec.shared_examples 'Subscribing to a nil class report' do
     given!("auto_report_#{interval}".to_sym) do
       create :automated_report,
              interval: interval,
-             report_class: report_class
+             report_class: report_class,
+             source: source
     end
   end
 

--- a/spec/support/utilization_reports.rb
+++ b/spec/support/utilization_reports.rb
@@ -15,7 +15,7 @@ RSpec.shared_context 'Utilization Report' do
 
   context 'a utilization report' do
     it 'must contain type, header, title' do
-      expect(report).to include(type: type, title: title, header: header)
+      expect(report).to include(type: type, title: output_title, header: header)
     end
   end
 

--- a/spec/support/utilization_reports.rb
+++ b/spec/support/utilization_reports.rb
@@ -28,9 +28,7 @@ RSpec.shared_context 'Utilization Report' do
       objects.each_with_object({}) do |o, a|
         events = Array.new(rand(1..5)) do
           time = Time.at(rand(start.to_i..finish.to_i)).utc
-          create(:discovery_service_event, :response,
-                 target => o.entity_id,
-                 timestamp: time)
+          create_event(time, o.entity_id)
         end
 
         a[o.id] = events.length


### PR DESCRIPTION
Hi @smangelsdorf 

As discussed in #176, here's the promised feature.

It adds the concept of a selectable session data source throughout the code base - the session data source can either point to DiscoveryServiceEvent or FederatedLoginEvent.

Key highligths are:
* I had to add make FederatedLoginEvent support the same functions as DiscoveryLoginEvent does - this was done by adding scope and foreign key definitions to FederatedLoginEvent.
  * I did not have to add the attribute aliases - I instead got round by parameterizing the `idp_sessions` / `sp_sessions` queries.
* On the report form, users can select the session source
* This selection gets passed through the controllers to report constructor objects.
* An installation can be configure the site-wide default for the selection (and in the absence of the setting, it defaults to 'DS')
* The public reports have no form and only use the site-wide default
* Report subscriptions carry the source with them (as per the form that generated the reports).
  * ... and so it's possible to subscribe to the same report twice, with different sources...
  * and the source the subscription is tied to is displayed on the Subscriptions list
  * This also means I've had to add a migration to add the source column to automated_reports.
  * And for reports that need_source?, the `source` parameter is required
  * So for some admin reports, I had to hide the Subscribe button if source is not set in the context - i.e., only display the Subscribe button after the report form is submitted and the report is rendered.
* And I've added another migration to add an index to federated_login_events to improve performance.
* An AutomatedReports object validates that source is set only iff report_class is a report that needs a source - that makes it tighter but makes correct tests slightly more tedious (and may complicate data migration - see below)
* Because source can now be either DS or IdP, I've removed the `'AAF Discovery Service'` references from the report title pages
* And I've instead added the source being used to the report title itself.  Does not look particularly great - I'm happy to adjust if you suggest a different place in the report where to state the source used.
* I have updated all tests and get a clean pass.
* And Rubocop gives me a clean pass two.

Please let me know whether you're happy to merge this or whether you have any concerns to be resolved.

Possible issues I see:
* Code coverage is not 100% - there are two uncovered code paths
* One is in AutomatedReport.source_if_needed?  - which would return the site-wide default for report subscriptions created before this is introduced.  I'd like to hear your opinion on how to handle this - whether to convert all NULL source values (where needs_source? == true) to site-wide default (or 'DS') - or whether to leave database with objects that may not validate.  If updating the database, we might actually remove the use of the default from this line that otherwise never gets hit.
* Another uncovered line is in the `scope` I added on FederatedLoginEvent - because the tests do not exercise the IdP session source properly.  Would you have a recommendation on how to adjust the tests to run over `source` ranging over `[ 'DS', 'IdP' ]` ?
* The change I did to add the source to report title are not seen for  TabularReports yet - because tabular reports do not display the title yet.  I have not found may way through the javascript code yet to make the title visible (which I'd consider a generic bugfix).  I can add it to this PR (some pointers on where to look would be appreciated), but I'd also wait for you feedback on putting the data source name into the report titles (as I see adding the source as another subtitle as another feasible option)

How's the PR looking to you?

Cheers,
Vlad
