### PR TITLE
Config: use secure session cookies

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -4,6 +4,7 @@ redis_namespace = "reporting-service:#{Rails.env}:session"
 session_store_opts = {
   redis_server: "redis://127.0.0.1:6379/0/#{redis_namespace}",
   expire_in: 3600,
+  secure: true,
   key: '_reporting-service-session'
 }
 


### PR DESCRIPTION

Rails defaults to not marking cookies as secure.

Prevent cookie theft over plain http: mark cookies as secure

This will apply to the Ruby stack across the board - I may send another one for IdE, but you may wish to consider applying the same change to all other projects...

Cheers,
Vlad