### PR TITLE
Remove IdE integration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,6 @@ gem 'redis-rails'
 gem 'accession'
 gem 'implicit-schema'
 gem 'rapid-rack'
-gem 'super-identity'
 gem 'valhammer'
 
 gem 'aws-sdk', '~> 2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -328,7 +328,6 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    super-identity (0.1.0)
     temple (0.8.1)
     terminal-notifier-guard (1.7.0)
     terminal-table (1.8.0)
@@ -409,7 +408,6 @@ DEPENDENCIES
   shoulda-matchers
   simplecov
   slim
-  super-identity
   terminal-notifier-guard
   therubyracer
   timecop

--- a/config/reporting_service.yml.dist
+++ b/config/reporting_service.yml.dist
@@ -4,13 +4,11 @@ mail:
   port: 1025
   address: localhost
 environment_string: Development
-ide:
-  host: ide.test.aaf.edu.au
-  cert: config/api-client.crt
-  key: config/api-client.key
-  admin_entitlements:
-    - urn:mace:aaf.edu.au:ide:internal:aaf-admin
-    - urn:mace:aaf.edu.au:ide:internal:aaf-reporting
+admins:
+  "shared_token_value":
+    - "urn:mace:aaf.edu.au:ide:internal:aaf-admin"
+  "shared_token_value2":
+    - "urn:mace:aaf.edu.au:ide:internal:aaf-admin"
 federationregistry:
   host: manager.test.aaf.edu.au
   secret: 'This is the shared secret used for authenticating to the FR export API'

--- a/spec/features/administrator_reports_spec.rb
+++ b/spec/features/administrator_reports_spec.rb
@@ -20,12 +20,12 @@ RSpec.feature 'Administrator Reports' do
     end
 
     background do
+      entitlements = ['urn:mace:aaf.edu.au:ide:internal:aaf-admin']
+      admins = Rails.application.config.reporting_service.admins
+      admins[user.shared_token.to_sym] = entitlements
+
       attrs = create(:aaf_attributes, :from_subject, subject: user)
       RapidRack::TestAuthenticator.jwt = create(:jwt, aaf_attributes: attrs)
-
-      entitlements = 'urn:mace:aaf.edu.au:ide:internal:aaf-admin'
-
-      stub_ide(shared_token: user.shared_token, entitlements: [entitlements])
 
       visit '/auth/login'
       click_button 'Login'

--- a/spec/features/automated_report_instances_spec.rb
+++ b/spec/features/automated_report_instances_spec.rb
@@ -39,8 +39,6 @@ RSpec.feature 'automated report instances' do
       attrs = create(:aaf_attributes, :from_subject, subject: user)
       RapidRack::TestAuthenticator.jwt = create(:jwt, aaf_attributes: attrs)
 
-      stub_ide(shared_token: user.shared_token, entitlements: [])
-
       visit '/auth/login'
       click_button 'Login'
     end
@@ -142,9 +140,10 @@ RSpec.feature 'automated report instances' do
 
       identifier = organization.identifier
       entitlements =
-        "urn:mace:aaf.edu.au:ide:internal:organization:#{identifier}"
+        ["urn:mace:aaf.edu.au:ide:internal:organization:#{identifier}"]
 
-      stub_ide(shared_token: user.shared_token, entitlements: [entitlements])
+      admins = Rails.application.config.reporting_service.admins
+      admins[user.shared_token.to_sym] = entitlements
 
       visit '/auth/login'
       click_button 'Login'
@@ -274,9 +273,9 @@ RSpec.feature 'automated report instances' do
 
         identifier = organization.identifier
         entitlements =
-          "urn:mace:aaf.edu.au:ide:internal:organization:#{identifier}"
-
-        stub_ide(shared_token: user.shared_token, entitlements: [entitlements])
+          ["urn:mace:aaf.edu.au:ide:internal:organization:#{identifier}"]
+        admins = Rails.application.config.reporting_service.admins
+        admins[user.shared_token.to_sym] = entitlements
 
         visit '/auth/login'
         click_button 'Login'
@@ -298,8 +297,9 @@ RSpec.feature 'automated report instances' do
         attrs = create(:aaf_attributes, :from_subject, subject: user)
         RapidRack::TestAuthenticator.jwt = create(:jwt, aaf_attributes: attrs)
 
-        entitlements = 'urn:mace:aaf.edu.au:ide:internal:aaf-admin'
-        stub_ide(shared_token: user.shared_token, entitlements: [entitlements])
+        entitlements = ['urn:mace:aaf.edu.au:ide:internal:aaf-admin']
+        admins = Rails.application.config.reporting_service.admins
+        admins[user.shared_token.to_sym] = entitlements
 
         visit '/auth/login'
         click_button 'Login'

--- a/spec/features/automated_reports_spec.rb
+++ b/spec/features/automated_reports_spec.rb
@@ -51,8 +51,6 @@ RSpec.feature 'automated report' do
         attrs = create(:aaf_attributes, :from_subject, subject: user)
         RapidRack::TestAuthenticator.jwt = create(:jwt, aaf_attributes: attrs)
 
-        stub_ide(shared_token: user.shared_token)
-
         visit '/auth/login'
         click_button 'Login'
         visit '/subscriber_reports'
@@ -86,8 +84,6 @@ RSpec.feature 'automated report' do
       background do
         attrs = create(:aaf_attributes, :from_subject, subject: user_02)
         RapidRack::TestAuthenticator.jwt = create(:jwt, aaf_attributes: attrs)
-
-        stub_ide(shared_token: user_02.shared_token)
 
         visit '/auth/login'
         click_button 'Login'

--- a/spec/features/compliance_reports_spec.rb
+++ b/spec/features/compliance_reports_spec.rb
@@ -17,8 +17,6 @@ RSpec.feature 'Compliance Reports' do
     attrs = create(:aaf_attributes, :from_subject, subject: user)
     RapidRack::TestAuthenticator.jwt = create(:jwt, aaf_attributes: attrs)
 
-    stub_ide(shared_token: user.shared_token)
-
     visit '/auth/login'
     click_button 'Login'
   end

--- a/spec/features/federation_reports_spec.rb
+++ b/spec/features/federation_reports_spec.rb
@@ -10,8 +10,6 @@ RSpec.feature 'Federation Reports' do
     attrs = create(:aaf_attributes, :from_subject, subject: user)
     RapidRack::TestAuthenticator.jwt = create(:jwt, aaf_attributes: attrs)
 
-    stub_ide(shared_token: user.shared_token)
-
     visit '/auth/login'
     click_button 'Login'
   end

--- a/spec/features/identity_provider_reports_spec.rb
+++ b/spec/features/identity_provider_reports_spec.rb
@@ -16,9 +16,9 @@ RSpec.feature 'Identity Provider Reports' do
 
       identifier = organization.identifier
       entitlements =
-        "urn:mace:aaf.edu.au:ide:internal:organization:#{identifier}"
-
-      stub_ide(shared_token: user.shared_token, entitlements: [entitlements])
+        ["urn:mace:aaf.edu.au:ide:internal:organization:#{identifier}"]
+      admins = Rails.application.config.reporting_service.admins
+      admins[user.shared_token.to_sym] = entitlements
 
       visit '/auth/login'
       click_button 'Login'
@@ -118,9 +118,6 @@ RSpec.feature 'Identity Provider Reports' do
 
       attrs = create(:aaf_attributes, :from_subject, subject: user)
       RapidRack::TestAuthenticator.jwt = create(:jwt, aaf_attributes: attrs)
-
-      stub_ide(shared_token: user.shared_token, entitlements: [nil])
-      stub_ide(shared_token: user.shared_token)
 
       visit '/auth/login'
       click_button 'Login'

--- a/spec/features/login_spec.rb
+++ b/spec/features/login_spec.rb
@@ -8,8 +8,6 @@ RSpec.feature 'Login Process' do
   background do
     attrs = create(:aaf_attributes, :from_subject, subject: user)
     RapidRack::TestAuthenticator.jwt = create(:jwt, aaf_attributes: attrs)
-
-    stub_ide(shared_token: user.shared_token)
   end
 
   scenario 'clicking "Log In" from the welcome page' do

--- a/spec/features/service_provider_reports_spec.rb
+++ b/spec/features/service_provider_reports_spec.rb
@@ -16,9 +16,9 @@ RSpec.feature 'Service Provider Reports' do
 
       identifier = organization.identifier
       entitlements =
-        "urn:mace:aaf.edu.au:ide:internal:organization:#{identifier}"
-
-      stub_ide(shared_token: user.shared_token, entitlements: [entitlements])
+        ["urn:mace:aaf.edu.au:ide:internal:organization:#{identifier}"]
+      admins = Rails.application.config.reporting_service.admins
+      admins[user.shared_token.to_sym] = entitlements
 
       visit '/auth/login'
       click_button 'Login'
@@ -118,9 +118,6 @@ RSpec.feature 'Service Provider Reports' do
 
       attrs = create(:aaf_attributes, :from_subject, subject: user)
       RapidRack::TestAuthenticator.jwt = create(:jwt, aaf_attributes: attrs)
-
-      stub_ide(shared_token: user.shared_token, entitlements: [nil])
-      stub_ide(shared_token: user.shared_token)
 
       visit '/auth/login'
       click_button 'Login'

--- a/spec/features/subscriber_reports_dashboard_spec.rb
+++ b/spec/features/subscriber_reports_dashboard_spec.rb
@@ -9,8 +9,6 @@ RSpec.feature 'Subscriber Reports' do
     attrs = create(:aaf_attributes, :from_subject, subject: user)
     RapidRack::TestAuthenticator.jwt = create(:jwt, aaf_attributes: attrs)
 
-    stub_ide(shared_token: user.shared_token)
-
     visit '/auth/login'
     click_button 'Login'
     visit '/subscriber_reports'

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -19,7 +19,6 @@ ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
   include FactoryBot::Syntax::Methods
-  config.include SuperIdentity::TestStub
 
   config.use_transactional_fixtures = false
 


### PR DESCRIPTION
Removes reliance on IdE and instead deploys a simple mapping of AEPST to Entitlement strings within the application config file.

Fixes #195.