### PR TITLE
CVE-2017-1002201

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ log
 vendor
 .DS_Store
 dump.rdb
+.idea

--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,7 @@ group :development, :test do
   gem 'launchy', require: false
   gem 'poltergeist', require: false
 
-  gem 'brakeman', '~> 3.0.0', require: false
+  gem 'brakeman', require: false
   gem 'simplecov', require: false
 
   gem 'guard', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,16 +69,7 @@ GEM
     aws-sigv4 (1.1.0)
       aws-eventstream (~> 1.0, >= 1.0.2)
     bindata (2.4.4)
-    brakeman (3.0.5)
-      erubis (~> 2.6)
-      fastercsv (~> 1.5)
-      haml (>= 3.0, < 5.0)
-      highline (~> 1.6.20)
-      multi_json (~> 1.2)
-      ruby2ruby (~> 2.1.1)
-      ruby_parser (~> 3.7.0)
-      sass (~> 3.0)
-      terminal-table (~> 1.4)
+    brakeman (4.7.0)
     builder (3.2.3)
     byebug (11.0.0)
     capybara (3.14.0)
@@ -110,8 +101,7 @@ GEM
       i18n (>= 0.7)
     fakeredis (0.7.0)
       redis (>= 3.2, < 5.0)
-    fastercsv (1.5.5)
-    ffi (1.10.0)
+    ffi (1.11.1)
     formatador (0.2.5)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -142,10 +132,7 @@ GEM
       rubocop (~> 0.20)
     guard-unicorn (0.2.0)
       guard (>= 1.1)
-    haml (4.0.7)
-      tilt
     hashdiff (0.3.8)
-    highline (1.6.21)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
     implicit-schema (0.0.1)
@@ -180,7 +167,7 @@ GEM
     mini_mime (1.0.1)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
-    multi_json (1.13.1)
+    multi_json (1.14.1)
     mysql2 (0.5.2)
     nenv (0.3.0)
     nio4r (2.3.1)
@@ -291,14 +278,9 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.10.0)
-    ruby2ruby (2.1.4)
-      ruby_parser (~> 3.1)
-      sexp_processor (~> 4.0)
     ruby_dep (1.5.0)
-    ruby_parser (3.7.3)
-      sexp_processor (~> 4.1)
     safe_yaml (1.0.5)
-    sass (3.7.3)
+    sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -309,7 +291,6 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    sexp_processor (4.12.0)
     shellany (0.0.1)
     shoulda-matchers (4.0.1)
       activesupport (>= 4.2.0)
@@ -330,14 +311,12 @@ GEM
       sprockets (>= 3.0.0)
     temple (0.8.1)
     terminal-notifier-guard (1.7.0)
-    terminal-table (1.8.0)
-      unicode-display_width (~> 1.1, >= 1.1.1)
     therubyracer (0.12.3)
       libv8 (~> 3.16.14.15)
       ref
     thor (0.19.4)
     thread_safe (0.3.6)
-    tilt (2.0.9)
+    tilt (2.0.10)
     timecop (0.9.1)
     torba (1.0.1)
       thor (~> 0.19.1)
@@ -348,7 +327,7 @@ GEM
       thread_safe (~> 0.1)
     uglifier (4.1.20)
       execjs (>= 0.3.0, < 3)
-    unicode-display_width (1.5.0)
+    unicode-display_width (1.6.0)
     unicorn (5.5.0)
       kgio (~> 2.6)
       raindrops (~> 0.7)
@@ -374,7 +353,7 @@ DEPENDENCIES
   aaf-lipstick
   accession
   aws-sdk (~> 2)
-  brakeman (~> 3.0.0)
+  brakeman
   byebug
   capybara
   database_cleaner
@@ -418,4 +397,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.16.0
+   2.0.1


### PR DESCRIPTION
In haml versions prior to version 5.0.0.beta.2, when using user input to
perform tasks on the server, characters like < > " ' must be escaped
properly. In this case, the ' character was missed. An attacker can
manipulate the input to introduce additional attributes, potentially
executing code.