### PR TITLE
DB: change all t.timestamp fields to use t.datetime

### DIFF
--- a/db/migrate/20200209214427_change_timestamp_type.rb
+++ b/db/migrate/20200209214427_change_timestamp_type.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class ChangeTimestampType < ActiveRecord::Migration[4.2]
+  def change
+    change_column :federated_login_events, :timestamp, :datetime, null: false
+    change_column :incoming_f_ticks_events, :timestamp, :datetime, null: false
+    change_column :automated_report_instances, :range_end, :datetime, null: false
+    change_column :activations, :activated_at, :datetime, null: false
+    change_column :activations, :deactivated_at, :datetime, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2017_05_16_001834) do
+ActiveRecord::Schema.define(version: 2020_02_09_214427) do
 
   create_table "activations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin", force: :cascade do |t|
     t.string "federation_object_type", null: false
     t.integer "federation_object_id", null: false
-    t.timestamp "activated_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
-    t.timestamp "deactivated_at"
+    t.datetime "activated_at", null: false
+    t.datetime "deactivated_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
@@ -43,7 +43,7 @@ ActiveRecord::Schema.define(version: 2017_05_16_001834) do
 
   create_table "automated_report_instances", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin", force: :cascade do |t|
     t.integer "automated_report_id", null: false
-    t.timestamp "range_end", default: -> { "CURRENT_TIMESTAMP" }, null: false
+    t.datetime "range_end", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "identifier", null: false
@@ -95,7 +95,7 @@ ActiveRecord::Schema.define(version: 2017_05_16_001834) do
     t.string "asserting_party", null: false
     t.string "result", null: false
     t.string "hashed_principal_name", null: false
-    t.timestamp "timestamp", default: -> { "CURRENT_TIMESTAMP" }, null: false
+    t.datetime "timestamp", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["hashed_principal_name"], name: "index_federated_login_events_on_hashed_principal_name"
@@ -125,7 +125,7 @@ ActiveRecord::Schema.define(version: 2017_05_16_001834) do
     t.string "data", limit: 4096, null: false
     t.string "ip", null: false
     t.boolean "discarded", default: false, null: false
-    t.timestamp "timestamp", default: -> { "CURRENT_TIMESTAMP" }, null: false
+    t.datetime "timestamp", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["discarded"], name: "index_incoming_f_ticks_events_on_discarded"


### PR DESCRIPTION
Fixes #210

In MySQL, TIMESTAMP is stored as unixt time integer - and even when storing a
UTC timestamp value into the field, MySQL treats it as a local timestamp in the
server timezone - and applies a conversion to UTC, converting back upon
retrieval.

Besides this being additional overhead, it also breaks when the UTC timestamp
stored falls on a period which does not exist in the local timezone (because of
DST change) - but is otherwise a perfectly valid UTC timestamp.

The DATETIME type does not have any of these downaides and is more suitable for
storing datetime values where the application knows what timezone they're in
(UTC in case of Reporting Service) and stops MySQL from making a (possibly
wrong) guess.

All rspec tests pass.