### PR TITLE
Require 'net/http' where it's needed

### DIFF
--- a/app/jobs/concerns/query_federation_registry.rb
+++ b/app/jobs/concerns/query_federation_registry.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'net/http'
+
 module QueryFederationRegistry
   def fr_objects(sym, path)
     @fr_objects ||= {}

--- a/app/jobs/update_from_rapid_connect.rb
+++ b/app/jobs/update_from_rapid_connect.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'net/http'
+
 class UpdateFromRapidConnect
   def perform
     RapidConnectService.transaction do


### PR DESCRIPTION
This was causing cron jobs to fail, with the error:

```
app/jobs/concerns/query_federation_registry.rb:18:in `fr_data': uninitialized constant Net::HTTP (NameError)
```