### PR TITLE
DB: permit hashed_principal_name to be NULL

### DIFF
--- a/db/migrate/20200219023010_permit_null_hashed_pn.rb
+++ b/db/migrate/20200219023010_permit_null_hashed_pn.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class PermitNullHashedPn < ActiveRecord::Migration[4.2]
+  def change
+    change_column :federated_login_events, :hashed_principal_name, :string, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_09_214427) do
+ActiveRecord::Schema.define(version: 2020_02_19_023010) do
 
   create_table "activations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin", force: :cascade do |t|
     t.string "federation_object_type", null: false
@@ -94,7 +94,7 @@ ActiveRecord::Schema.define(version: 2020_02_09_214427) do
     t.string "relying_party", null: false
     t.string "asserting_party", null: false
     t.string "result", null: false
-    t.string "hashed_principal_name", null: false
+    t.string "hashed_principal_name"
     t.datetime "timestamp", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/spec/models/federated_login_event_spec.rb
+++ b/spec/models/federated_login_event_spec.rb
@@ -22,7 +22,6 @@ RSpec.describe FederatedLoginEvent, type: :model do
       it { is_expected.to validate_presence_of(:asserting_party) }
       it { is_expected.to validate_presence_of(:timestamp) }
       it { is_expected.to validate_presence_of(:result) }
-      it { is_expected.to validate_presence_of(:hashed_principal_name) }
     end
 
     context 'fields' do


### PR DESCRIPTION
When an IdP is not configured with idp.fticks.salt, PN is omited from the F-Ticks record.

With the DB marking hashed_principal_name as NOT NULL, processing of such a record fails and the record is discarded.

There is no reason to make hashed_principal_name required.

F-Ticks spec [1] also explicitly says:

    4.  Common F-ticks Attributes

    In general a log consumer should not assume that any one attribute is
    present.  Depending on the situation any one of these (or any other
    defined attributes) may be missing from an F-ticks message.

So remove the NOT NULL constraint.

[1](https://tools.ietf.org/html/draft-johansson-fticks-00#page-3)