### PR TITLE
Config: use correct key for session expiry

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -5,7 +5,7 @@ session_cookie_secure = Rails.env.production?
 
 session_store_opts = {
   redis_server: "redis://127.0.0.1:6379/0/#{redis_namespace}",
-  expire_in: 3600,
+  expire_after: 3600,
   secure: session_cookie_secure,
   key: '_reporting-service-session'
 }


### PR DESCRIPTION
As per https://github.com/redis-store/redis-rails
the correct key name is `expiry_after`.

When using `expire_in`, it does correctly set the Redis key expiry date,
but is ignored when constructing the cookie.

When using `expire_after`, the expiry is correctly applied to both
the Redis key and the session cookie.