### PR TITLE
Ignore invalid events from DS

### DIFF
--- a/app/jobs/receive_events_from_discovery_service.rb
+++ b/app/jobs/receive_events_from_discovery_service.rb
@@ -33,7 +33,7 @@ class ReceiveEventsFromDiscoveryService
 
         DiscoveryServiceEvent
           .create_with(event)
-          .find_or_create_by!(event.slice(:unique_id, :phase))
+          .find_or_create_by(event.slice(:unique_id, :phase))
       end
     end
   end

--- a/spec/jobs/receive_events_from_discovery_service_spec.rb
+++ b/spec/jobs/receive_events_from_discovery_service_spec.rb
@@ -82,16 +82,6 @@ RSpec.describe ReceiveEventsFromDiscoveryService, type: :job do
             .to have_attributes(attrs)
         end
       end
-
-      context 'when an event is not able to be stored' do
-        let(:events) do
-          events_attrs.dup.unshift(timestamp: Time.zone.now)
-        end
-
-        it 'raises an exception' do
-          expect { run }.to raise_error(ActiveRecord::RecordInvalid)
-        end
-      end
     end
 
     context 'when a message is in the queue' do


### PR DESCRIPTION
Invalid imports from DS logs threw off reporting ingest. These events
are not important to us so we should simply drop them and carry on.

Specific case leading to this change was an entityID in excess of 255
char, we don't support registration of entityID that long to the request
was clearly junk from the wider internet.