### PR TITLE
Fix typo in report title (SP Dest Services => Source IdP)

### DIFF
--- a/app/views/service_provider_reports/source_identity_providers_report.html.slim
+++ b/app/views/service_provider_reports/source_identity_providers_report.html.slim
@@ -9,7 +9,7 @@
            locals: { target: @entity_id,
                      report_class: 'ServiceProviderSourceIdentityProvidersReport' })
 
-h1 Service Provider Destination Services Report
+h1 Service Provider Source Identity Provider Report
 
 p Graphs the number of sessions for a Service which were
   authenticated via each Identity Provider


### PR DESCRIPTION
Fix report title to match what the report is (and so also match the filename it's in and the link that leads to it).