### PR TITLE
Fix: fr-sync: functioning objects must have empty deactivation time

### DIFF
--- a/app/jobs/update_from_federation_registry.rb
+++ b/app/jobs/update_from_federation_registry.rb
@@ -106,9 +106,8 @@ class UpdateFromFederationRegistry
   def activate_object(obj, obj_data)
     activation_attrs = { activated_at: obj_data[:created_at] }
 
-    unless obj_data[:functioning]
-      activation_attrs[:deactivated_at] = obj_data[:updated_at]
-    end
+    activation_attrs[:deactivated_at] =
+      obj_data[:functioning] ? nil : obj_data[:updated_at]
 
     obj.activations.find_or_initialize_by({}).update!(activation_attrs)
   end

--- a/spec/jobs/update_from_federation_registry_spec.rb
+++ b/spec/jobs/update_from_federation_registry_spec.rb
@@ -174,6 +174,18 @@ RSpec.describe UpdateFromFederationRegistry, type: :job do
           )
         end
       end
+
+      context 'when the object is deactivated but functioning' do
+        let!(:activation) { create(:activation, :deactivated, federation_object: object) }
+
+        it 'marks the object as activated' do
+          expect { run }.not_to change(object.activations, :count)
+          expect(object.activations.first).to have_attributes(
+            activated_at: Time.parse(obj_data[:created_at]).utc,
+            deactivated_at: nil
+          )
+        end
+      end
     end
 
     shared_examples 'sync of a removed object' do


### PR DESCRIPTION
Otherwise, these objects would appear as deactivated to the reporting service.

This in particular applies to objects that were not approved in FR yet when synced into Reporting Service - they were seen as not functioning, and were created as deactivated ... and would otherwise never get (re)activated in Reporting Service, even when they become activate in FR.

@bradleybeddoes , I ran into this when wondering why I'm not seeing an SP in the list on the Reporting Service ... and found this issue, hiding SPs that were synced before they got approved.

Fix so far tested in our TEST environment, does exactly what it should.