### PR TITLE
Revert `execJS` gem to `2.7.0`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,7 +95,7 @@ GEM
     docile (1.4.0)
     erubi (1.10.0)
     erubis (2.7.0)
-    execjs (2.8.1)
+    execjs (2.7.0)
     factory_bot (4.11.1)
       activesupport (>= 3.0.0)
     factory_bot_rails (4.11.1)


### PR DESCRIPTION
For details on this issue, refer here: https://github.com/ausaccessfed/stockpile/issues/89

This is part of https://github.com/ausaccessfed/stockpile/issues/87
