### PR TITLE
Add platform `x86_64-linux`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -171,6 +171,7 @@ GEM
     launchy (2.5.0)
       addressable (~> 2.7)
     libv8 (3.16.14.19)
+    libv8 (3.16.14.19-x86_64-linux)
     listen (3.7.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -189,6 +190,8 @@ GEM
     nenv (0.3.0)
     nio4r (2.5.8)
     nokogiri (1.13.3-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.13.3-x86_64-linux)
       racc (~> 1.4)
     notiffany (0.1.3)
       nenv (~> 0.1)
@@ -305,8 +308,6 @@ GEM
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 1.7.0, < 2.0)
-    rubocop-rspec (2.9.0)
-      rubocop (~> 1.19)
     ruby-progressbar (1.11.0)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
@@ -376,6 +377,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-20
+  x86_64-linux
 
 DEPENDENCIES
   aaf-gumboot
@@ -413,7 +415,6 @@ DEPENDENCIES
   rspec-rails
   rubocop
   rubocop-rails
-  rubocop-rspec (~> 2.9)
   sass-rails
   shoulda-matchers
   simplecov


### PR DESCRIPTION
The following scripts are failing to run:

- receive_events.sh 
- update.sh

I checked aws log groups for the instance where it is running and the only log I could find was that <script> finished with exit code 1

I connected to the box and attempted to run the scripts manually to try and see the log output, however the following error appeared: 

```shell
TEST <redacted>@<redacted>:$ ./receive_events.sh
Your bundle only supports platforms ["x86_64-darwin-20"] but your local platform is x86_64-linux. Add the current platform to the lockfile with `bundle lock --add-platform x86_64-linux` and try again.

TEST <redacted>@<redacted>:$ ./update.sh
Your bundle only supports platforms ["x86_64-darwin-20"] but your local platform is x86_64-linux. Add the current platform to the lockfile with `bundle lock --add-platform x86_64-linux` and try again.
```

see https://github.com/rubygems/rubygems/issues/4269 for more details

