### PR TITLE
Two minor fixes post NNWO: secure cookies and more env vars

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    aaf-gumboot (2.6.2)
+    aaf-gumboot (2.6.3)
       accession
     aaf-lipstick (4.9.2)
       erubis

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -14,4 +14,5 @@
 
 Rails.application.config.session_store :active_record_store,
                                        key: "_#{Rails.application.config.reporting_service.redis[:namespace]}-session",
+                                       secure: Rails.env.production?,
                                        expires: 90.minutes

--- a/config/reporting_service_configuration.rb
+++ b/config/reporting_service_configuration.rb
@@ -43,7 +43,7 @@ module ReportingService
           ],
           federation_object_entitlement_prefix: 'urn:mace:aaf.edu.au:ide:internal'
         },
-        default_session_source: 'DS',
+        default_session_source: ENV.fetch('DEFAULT_SESSION_SOURCE', 'DS'),
         mail: {
           from: ENV.fetch('EMAIL_FROM', 'noreply@example.com'),
           port: ENV.fetch('EMAIL_PORT', 1025).to_i,
@@ -53,7 +53,7 @@ module ReportingService
         url_options: {
           base_url: ENV.fetch('BASE_URL', 'http://localhost:8082')
         },
-        time_zone: 'Australia/Brisbane'
+        time_zone: ENV.fetch('TIME_ZONE', 'Australia/Brisbane')
       }
     end
 

--- a/config/reporting_service_configuration.rb
+++ b/config/reporting_service_configuration.rb
@@ -12,7 +12,7 @@ module ReportingService
   # rubocop:disable Metrics/ClassLength
   class ConfigurationGenerator
     def build_configuration
-      base_config.merge(admins_config, redis, federation_registry)
+      base_config.merge(admins_config, redis, federation_registry, rapid_connect)
     end
 
     private
@@ -21,12 +21,6 @@ module ReportingService
       {
         version:,
         discovery_service_hostname: ENV.fetch('DISCOVERY_SERVICE_HOSTNAME', 'ds.test.aaf.edu.au'),
-        rapid_connect: {
-          host: ENV.fetch('RAPID_CONNECT_HOST', 'rapid.test.aaf.edu.au'),
-          secret: ENV.fetch('RAPID_CONNECT_SECRET',
-                            'This is the shared secret used for authenticating to the Rapid export API'),
-          rack: rapid_connect_rack
-        },
         sqs: {
           fake: ENV.fetch('SQS_FAKE', false),
           region: ENV.fetch('SQS_REGION', 'localhost'),
@@ -87,6 +81,15 @@ module ReportingService
           host: ENV.fetch('FEDERATION_REGISTRY_DB_HOST', ''),
           port: ENV.fetch('FEDERATION_REGISTRY_DB_PORT', '3306')
         }
+      } }
+    end
+
+    def rapid_connect
+      { rapid_connect: {
+        host: ENV.fetch('RAPID_CONNECT_HOST', 'rapid.test.aaf.edu.au'),
+        secret: ENV.fetch('RAPID_CONNECT_SECRET',
+                          'This is the shared secret used for authenticating to the Rapid export API'),
+        rack: rapid_connect_rack
       } }
     end
 


### PR DESCRIPTION
Hi @phyzical ,

I've started looking at rolling out the NNWO changes for us: found two minor issues:
* cookies lost their `secure` flag in `session_store` change
* move from config file to env vars ended up hard-coding some settings.  Adding env vars for those that we override - preserving existing values as defaults if not set.  `TIME_ZONE` matches what e.g. validator-service already uses.

Please let me know if happy to merge like this or if any changes are required.

Cheers,
Vlad
