### PR TITLE
 Two minor fixes post NNWO: secure cookies and more env vars

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -14,4 +14,5 @@
 
 Rails.application.config.session_store :active_record_store,
                                        key: "_#{Rails.application.config.reporting_service.redis[:namespace]}-session",
+                                       secure: Rails.env.production?,
                                        expires: 90.minutes

--- a/config/reporting_service_configuration.rb
+++ b/config/reporting_service_configuration.rb
@@ -43,7 +43,7 @@ module ReportingService
           ],
           federation_object_entitlement_prefix: 'urn:mace:aaf.edu.au:ide:internal'
         },
-        default_session_source: 'DS',
+        default_session_source: ENV.fetch('DEFAULT_SESSION_SOURCE', 'DS'),
         mail: {
           from: ENV.fetch('EMAIL_FROM', 'noreply@example.com'),
           port: ENV.fetch('EMAIL_PORT', 1025).to_i,
@@ -53,7 +53,7 @@ module ReportingService
         url_options: {
           base_url: ENV.fetch('BASE_URL', 'http://localhost:8082')
         },
-        time_zone: 'Australia/Brisbane'
+        time_zone: ENV.fetch('TIME_ZONE', 'Australia/Brisbane')
       }
     end
 


### PR DESCRIPTION
Hi @phyzical ,

I've started looking at rolling out the NNWO changes for us: found two minor issues:
* cookies lost their `secure` flag in `session_store` change
* move from config file to env vars ended up hard-coding some settings.  Adding env vars for those that we override - preserving existing values as defaults if not set.  `TIME_ZONE` matches what e.g. validator-service already uses.

Please let me know if happy to merge like this or if any changes are required.

Cheers,
Vlad
