### PR TITLE
Fixing redis expiry

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -33,7 +33,7 @@ module ReportingService
       url: config.reporting_service.redis[:url],
       ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE },
       namespace: config.reporting_service.redis[:namespace],
-      expire_in: 1.day
+      expires_in: 1.day
     }]
     config.redis_client = Redis.new(
       url: Rails.application.config.reporting_service.redis[:url],

--- a/config/reporting_service_configuration.rb
+++ b/config/reporting_service_configuration.rb
@@ -77,6 +77,7 @@ module ReportingService
 
     def federation_registry
       { federation_registry: {
+        enable_sync: ENV.fetch('FEDERATION_REGISTRY_ENABLE_SYNC', true),
         host: ENV.fetch('FEDERATION_REGISTRY_HOST', 'manager.test.aaf.edu.au'),
         secret: ENV.fetch('FEDERATION_REGISTRY_SECRET',
                           'This is the shared secret used for authenticating to the FR export API'),

--- a/config/reporting_service_configuration.rb
+++ b/config/reporting_service_configuration.rb
@@ -77,7 +77,7 @@ module ReportingService
 
     def federation_registry
       { federation_registry: {
-        enable_sync: ENV.fetch('FEDERATION_REGISTRY_ENABLE_SYNC', true),
+        enable_sync: ENV.fetch('FEDERATION_REGISTRY_ENABLE_SYNC', 'true') == 'true',
         host: ENV.fetch('FEDERATION_REGISTRY_HOST', 'manager.test.aaf.edu.au'),
         secret: ENV.fetch('FEDERATION_REGISTRY_SECRET',
                           'This is the shared secret used for authenticating to the FR export API'),

--- a/spec/jobs/receive_events_from_discovery_service_spec.rb
+++ b/spec/jobs/receive_events_from_discovery_service_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe ReceiveEventsFromDiscoveryService, type: :job do
       context 'when not syncing fr' do
         before do
           fr_config = Rails.application.config.reporting_service.federation_registry
-          fr_config[:enable_sync] = 'false'
+          fr_config[:enable_sync] = false
           allow(Rails.application.config.reporting_service).to receive(:federation_registry)
             .and_return(fr_config)
         end

--- a/spec/jobs/receive_events_from_discovery_service_spec.rb
+++ b/spec/jobs/receive_events_from_discovery_service_spec.rb
@@ -98,10 +98,8 @@ RSpec.describe ReceiveEventsFromDiscoveryService, type: :job do
 
       context 'when not syncing fr' do
         before do
-          fr_config = Rails.application.config.reporting_service.federation_registry
-          fr_config[:enable_sync] = false
           allow(Rails.application.config.reporting_service).to receive(:federation_registry)
-            .and_return(fr_config)
+            .and_return(Rails.application.config.reporting_service.federation_registry.merge(enable_sync: false))
         end
 
         it 'creates the events' do

--- a/spec/jobs/receive_events_from_discovery_service_spec.rb
+++ b/spec/jobs/receive_events_from_discovery_service_spec.rb
@@ -95,6 +95,25 @@ RSpec.describe ReceiveEventsFromDiscoveryService, type: :job do
             .to have_attributes(attrs)
         end
       end
+
+      context 'when not syncing fr' do
+        before do
+          fr_config = Rails.application.config.reporting_service.federation_registry
+          fr_config[:enable_sync] = false
+          allow(Rails.application.config.reporting_service).to receive(:federation_registry)
+            .and_return(fr_config)
+        end
+
+        it 'creates the events' do
+          expect { run }
+            .to change(DiscoveryServiceEvent, :count).by(events.length)
+
+          events_attrs.each do |attrs|
+            expect(DiscoveryServiceEvent.find_by(attrs.slice(:unique_id)))
+              .to have_attributes(attrs)
+          end
+        end
+      end
     end
 
     context 'when a message is in the queue' do

--- a/spec/jobs/receive_events_from_discovery_service_spec.rb
+++ b/spec/jobs/receive_events_from_discovery_service_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe ReceiveEventsFromDiscoveryService, type: :job do
       context 'when not syncing fr' do
         before do
           fr_config = Rails.application.config.reporting_service.federation_registry
-          fr_config[:enable_sync] = false
+          fr_config[:enable_sync] = 'false'
           allow(Rails.application.config.reporting_service).to receive(:federation_registry)
             .and_return(fr_config)
         end


### PR DESCRIPTION
Looks like when we moved to the inbuilt redis cache the default expiry is no longer being sent, fix up the name of the param to set default expiry