### PR TITLE
Have Sentry ignore Puma::HttpParserError

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -9,5 +9,10 @@ Sentry.init do |config|
   config.logger = Logger.new(ENV.fetch('STDOUT', $stdout))
   config.logger.level = Logger::WARN
   config.include_local_variables = true
+
+  # Puma raises this error when a client makes a malformed HTTP request. It responds appropriately with 400 Bad Request.
+  # We don't need to hear about that!
+  # See https://github.com/getsentry/sentry-ruby/pull/2026#issuecomment-1525031744.
+  config.excluded_exceptions << 'Puma::HttpParserError'
 end
 # :nocov:


### PR DESCRIPTION
Puma raises this error when a client makes a malformed HTTP request. It responds appropriately with 400 Bad Request. That's exactly what we want to happen! We don't need to be notified.

Reusing https://github.com/ausaccessfed/federationmanager/pull/2491